### PR TITLE
Fix inverted relay logic on KC868-A8

### DIFF
--- a/include/KC868A8_IO.h
+++ b/include/KC868A8_IO.h
@@ -4,9 +4,9 @@
  * Provides digitalWrite/digitalRead/pinMode redirection for KC868-A8 hardware.
  * Virtual pins (100+) are mapped to PCF8574 I2C expanders.
  * 
- * Relay outputs (100-107): PCF8574 @ 0x24, active LOW via ULN2003A
- *   - digitalWrite(pin, HIGH) → relay ON → PCF8574 bit = LOW
- *   - digitalWrite(pin, LOW)  → relay OFF → PCF8574 bit = HIGH
+ * Relay outputs (100-107): PCF8574 @ 0x24, active HIGH via ULN2003A
+ *   - digitalWrite(pin, HIGH) → relay ON → PCF8574 bit = HIGH
+ *   - digitalWrite(pin, LOW)  → relay OFF → PCF8574 bit = LOW
  * 
  * Digital inputs (110-117): PCF8574 @ 0x22, active LOW
  *   - digitalRead(pin) → HIGH = inactive, LOW = active (optocoupler triggered)

--- a/src/KC868A8_IO.cpp
+++ b/src/KC868A8_IO.cpp
@@ -3,12 +3,13 @@
  * 
  * Hardware:
  *   PCF8574 @ 0x24: 8-bit I/O expander for relay outputs
- *     - ULN2003A driver: LOW on PCF8574 = relay ON, HIGH = relay OFF
- *     - Active LOW logic
+ *     - ULN2003A driver: HIGH on PCF8574 = relay ON, LOW = relay OFF
+ *     - Active HIGH logic
  * 
  *   PCF8574 @ 0x22: 8-bit I/O expander for digital inputs
  *     - Optocoupled inputs: LOW when triggered (circuit closed)
  *     - Active LOW logic
+ *     - We invert so digitalRead returns HIGH when active
  * 
  * Virtual Pin Mapping:
  *   100-107: Relay outputs (PCF8574 @ 0x24, bits 0-7)
@@ -26,7 +27,7 @@
 KC868A8_IO KC868;
 
 KC868A8_IO::KC868A8_IO() 
-    : relayState(0xFF),  // All relays OFF initially (active LOW, so HIGH = OFF)
+    : relayState(0x00),  // All relays OFF initially (LOW = OFF)
       inputState(0x00),
       lastInputState(0x00),
       initialized(false) {
@@ -35,7 +36,7 @@ KC868A8_IO::KC868A8_IO()
 void KC868A8_IO::begin() {
     // I2C should already be initialized (Wire.begin in Setup.cpp)
     // Initialize relay outputs - all OFF
-    relayState = 0xFF;  // All HIGH = all relays OFF
+    relayState = 0x00;  // All LOW = all relays OFF
     Wire.beginTransmission(KC868_RELAY_I2C_ADDR);
     Wire.write(relayState);
     Wire.endTransmission();
@@ -71,11 +72,11 @@ void KC868A8_IO::digitalWrite(uint8_t pin, uint8_t value) {
     if (IS_KC868_RELAY_PIN(pin)) {
         uint8_t bit = pin - 100;
         if (value) {
-            // Relay ON → PCF8574 bit LOW (active LOW)
-            relayState &= ~(1 << bit);
-        } else {
-            // Relay OFF → PCF8574 bit HIGH
+            // Relay ON → PCF8574 bit HIGH
             relayState |= (1 << bit);
+        } else {
+            // Relay OFF → PCF8574 bit LOW
+            relayState &= ~(1 << bit);
         }
         writeOutputs();
     }
@@ -94,7 +95,7 @@ uint8_t KC868A8_IO::digitalRead(uint8_t pin) {
     if (IS_KC868_RELAY_PIN(pin)) {
         // Read current relay state
         uint8_t bit = pin - 100;
-        return !((relayState >> bit) & 1);  // Invert: HIGH = relay ON
+        return (relayState >> bit) & 1;  // HIGH = relay ON
     }
     
     return 0;
@@ -109,16 +110,16 @@ void KC868A8_IO::setRelay(uint8_t relayIndex, bool on) {
     if (relayIndex > 7) return;
     
     if (on) {
-        relayState &= ~(1 << relayIndex);   // LOW = relay ON
+        relayState |= (1 << relayIndex);    // HIGH = relay ON
     } else {
-        relayState |= (1 << relayIndex);    // HIGH = relay OFF
+        relayState &= ~(1 << relayIndex);   // LOW = relay OFF
     }
     writeOutputs();
 }
 
 bool KC868A8_IO::getRelay(uint8_t relayIndex) {
     if (relayIndex > 7) return false;
-    return !((relayState >> relayIndex) & 1);  // Invert: true = ON
+    return (relayState >> relayIndex) & 1;  // true = ON
 }
 
 bool KC868A8_IO::getInput(uint8_t inputIndex) {


### PR DESCRIPTION
## Problem

Die Relais-Logik auf dem KC868-A8 war invertiert:
- **Standardzustand:** Alle Relais (Pumpen etc.) waren EIN
- **Bei Start z.B. der Filtrationspumpe:** Das Relais wurde AUSgeschaltet
- **Bei Stop:** Das Relais wurde EINGeschaltet

## Ursache

Falsche Annahme über die ULN2003A-Treiber-Polarität. Der Kommentar sagte "active LOW" (PCF8574 LOW = Relay ON), aber die Hardware funktioniert anders:

| PCF8574 | ULN2003A | Relay |
|---------|----------|-------|
| HIGH    | Zieht durch (sinks) | **ON** |
| LOW     | Hochimpedanz (floats) | **OFF** |

## Korrektur

| Datei | Änderung |
|-------|----------|
| `KC868A8_IO.h` | Kommentare korrigiert |
| `KC868A8_IO.cpp` | `digitalWrite`: val=HIGH → bit setzen (war: löschen) |
| | `digitalRead` für Relais: Invertierung entfernt |
| | `setRelay`/`getRelay`: Polarität korrigiert |
| | Constructor/`begin`: `relayState=0x00` für alle AUS (war: 0xFF) |

## Testing

Kompilieren mit `pio run -e kc868_a8` und auf Hardware testen:
1. Nach Boot sollten alle Relais AUS sein
2. Filtrationspumpe starten → Relais EIN
3. Filtrationspumpe stoppen → Relais AUS