### PR TITLE
Fix PSI simulation: enable and integrate into AnalogPoll

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -52,12 +52,12 @@
 #define SIMU_POOL_LEVEL     0       // Pool water level simulation
 #define SIMU_PH             0       // pH sensor simulation
 #define SIMU_ORP            0       // ORP sensor simulation
-#define SIMU_PSI            0       // Pressure sensor simulation
+#define SIMU_PSI            1       // Pressure sensor simulation
 
 // Simulation default values (used when simulation is enabled)
 #define SIMU_PH_VALUE       7.2     // Default simulated pH
 #define SIMU_ORP_VALUE      720.0   // Default simulated ORP (mV)
-#define SIMU_PSI_VALUE      0.35    // Default simulated pressure (bar)
+#define SIMU_PSI_VALUE      0.1     // Default simulated pressure (bar)
 #define SIMU_CHL_LEVEL_VALUE  1     // Default: HIGH (tank not empty)
 #define SIMU_PH_LEVEL_VALUE   1     // Default: HIGH (tank not empty)
 #define SIMU_POOL_LEVEL_VALUE 1     // Default: HIGH (pool level OK)

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>                // Arduino framework
 #include "Config.h"
 #include "PoolMaster.h"
+#include "SensorSimulation.h"
 
 // Setup oneWire instances to communicate with temperature sensors (one bus per sensor)
 static OneWire oneWire_W(ONE_WIRE_BUS_W);
@@ -109,9 +110,17 @@ void AnalogPoll(void *pvParameters)
       adc_int.start();
 
       //PSI (water pressure)
-      samples_PSI.add(psi_sensor_value);        // compute average of PSI from last 5 measurements
-      PMData.PSIValue = (samples_PSI.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PSICALIBCOEFFS0) + PMConfig.get<double>(PSICALIBCOEFFS1);
-      PMData.PSIValue = (PMData.PSIValue < 0)? 0 : PMData.PSIValue;
+      #ifdef SENSOR_SIMULATION
+      if (SimSensor.isSimulating(SENSOR_PSI)) {
+        PMData.PSIValue = SimSensor.getSimulatedValue(SENSOR_PSI);
+      } else {
+      #endif
+        samples_PSI.add(psi_sensor_value);        // compute average of PSI from last 5 measurements
+        PMData.PSIValue = (samples_PSI.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PSICALIBCOEFFS0) + PMConfig.get<double>(PSICALIBCOEFFS1);
+        PMData.PSIValue = (PMData.PSIValue < 0)? 0 : PMData.PSIValue;
+      #ifdef SENSOR_SIMULATION
+      }
+      #endif
     }
     unlockI2C();
 
@@ -216,9 +225,17 @@ void AnalogPoll(void *pvParameters)
 #endif
 
         //PSI (water pressure)
-        samples_PSI.add(psi_sensor_value);        // compute average of PSI from last 5 measurements
-        PMData.PSIValue = (samples_PSI.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PSICALIBCOEFFS0) + PMConfig.get<double>(PSICALIBCOEFFS1);
-        PMData.PSIValue = (PMData.PSIValue < 0)? 0 : PMData.PSIValue;
+        #ifdef SENSOR_SIMULATION
+        if (SimSensor.isSimulating(SENSOR_PSI)) {
+          PMData.PSIValue = SimSensor.getSimulatedValue(SENSOR_PSI);
+        } else {
+        #endif
+          samples_PSI.add(psi_sensor_value);        // compute average of PSI from last 5 measurements
+          PMData.PSIValue = (samples_PSI.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PSICALIBCOEFFS0) + PMConfig.get<double>(PSICALIBCOEFFS1);
+          PMData.PSIValue = (PMData.PSIValue < 0)? 0 : PMData.PSIValue;
+        #ifdef SENSOR_SIMULATION
+        }
+        #endif
 
         Debug.print(DBG_DEBUG,"pH: %5.0f - %4.2f - ORP: %5.0f - %3.0fmV - PSI: %5.0f - %4.2fBar\r",
             ph_sensor_value,PMData.PhValue,orp_sensor_value,PMData.OrpValue,psi_sensor_value,PMData.PSIValue);


### PR DESCRIPTION
## Problem

PSI-Simulation funktionierte nicht:
- **PSI zeigte 4,47 bar** statt dem konfigurierten 0,1 bar
- **Sofortiger PSI-Fehler** beim Start der Filtrationspumpe → Pumpe wird gestoppt

## Ursache

Zwei Fehler:

1. **`SIMU_PSI` war deaktiviert** (`0`) — der ADS1115 ADC liest einen Unsinn-Wert (kein echter Drucksensor angeschlossen)
2. **Simulation nicht in `AnalogPoll()` integriert** — selbst mit `SIMU_PSI=1` wurde weiterhin der ADC-Wert für `PMData.PSIValue` verwendet

## Korrektur

| Datei | Änderung |
|-------|----------|
| `Config.h` | `SIMU_PSI=1` (aktiviert), `SIMU_PSI_VALUE=0.1` bar |
| `Loops.cpp` | `#include SensorSimulation.h` hinzugefügt |
| `Loops.cpp` | Beide `AnalogPoll`-Varianten: `SimSensor.isSimulating(SENSOR_PSI)` Check vor ADC-Verarbeitung |

## Testing

1. Kompilieren: `pio run -e kc868_a8`
2. Boot → PSI sollte 0,10 bar anzeigen
3. Filtrationspumpe starten → PSI bleibt stabil, kein Error