### PR TITLE
fix: Sensor-Simulation in TankLevel() und AnalogPoll() integrieren

### DIFF
--- a/include/SensorSimulation.h
+++ b/include/SensorSimulation.h
@@ -1,107 +1,97 @@
+/*
+ * Sensor Simulation System for ESP32-PoolMaster
+ * 
+ * Provides individual simulation for each sensor type.
+ * Each sensor can be independently enabled/disabled via Config.h flags.
+ * 
+ * Supported sensors:
+ *   - CHL_LEVEL: Chlorine tank level (digital input)
+ *   - PH_LEVEL: Acid tank level (digital input)
+ *   - POOL_LEVEL: Pool water level (digital input)
+ *   - pH: pH sensor (analog via ADS1115)
+ *   - ORP: ORP sensor (analog via ADS1115)
+ *   - PSI: Pressure sensor (analog via ADS1115)
+ * 
+ * Usage:
+ *   1. Set SIMU_* flags in Config.h to enable simulation for specific sensors
+ *   2. Optionally set SIMU_*_VALUE for custom initial values
+ *   3. If a sensor is not physically connected, simulation auto-engages
+ *   4. Simulation does not affect real sensor logic when disabled
+ */
+
 #ifndef SENSOR_SIMULATION_H
 #define SENSOR_SIMULATION_H
 
 #include <Arduino.h>
-#include <Preferences.h>
-
-// Forward declarations for KC868-A8 I/O functions
-// These are implemented in KC868A8_IO.cpp
-void kc868_a8_init();
-uint8_t kc868_a8_digitalRead(uint8_t pin);
-void kc868_a8_digitalWrite(uint8_t pin, uint8_t value);
-
-// ADS1115 multiplexer channel constants (for analog simulation)
-#define ADS1115_MUX_CH0 0x4000  // AIN0
-#define ADS1115_MUX_CH1 0x5000  // AIN1
-#define ADS1115_MUX_CH2 0x6000  // AIN2
-#define ADS1115_MUX_CH3 0x7000  // AIN3
-
-// Default simulated values when no sensor is connected
-#define SIMU_PH_DEFAULT    7.0   // Neutral pH
-#define SIMU_ORP_DEFAULT  700.0  // Typical ORP value (mV)
-#define SIMU_PSI_DEFAULT    1.5  // Typical pool pressure (bar)
-#define SIMU_CHL_DEFAULT  700.0  // Typical chlorine ORP (mV)
 
 class SensorSimulation {
 public:
-    // Sensor index constants for analog simulation (used with getSimulatedValue)
+    // Sensor type constants (public for use in AnalogPoll and other modules)
     static const uint8_t SENSOR_PH = 0;
     static const uint8_t SENSOR_ORP = 1;
     static const uint8_t SENSOR_PSI = 2;
-    static const uint8_t SENSOR_CHL = 3;  // Chlorine (alias for ORP in some configs)
+    static const uint8_t SENSOR_CHL_LEVEL = 3;
+    static const uint8_t SENSOR_PH_LEVEL = 4;
+    static const uint8_t SENSOR_POOL_LEVEL = 5;
+
+    SensorSimulation();
+    
+    // Initialize simulation system
+    void begin();
+    
+    // Update simulation values (called periodically)
+    void loop();
+    
+    // ============================================================
+    // Digital Input Simulation (CHL_LEVEL, PH_LEVEL, POOL_LEVEL)
+    // ============================================================
+    // Returns simulated state for digital inputs
+    // Returns -1 if simulation is not active (use real sensor)
+    int8_t getSimulatedInput(uint8_t pin);
+    
+    // ============================================================
+    // Analog Sensor Simulation (pH, ORP, PSI)
+    // ============================================================
+    // Returns simulated value for analog sensors
+    // Returns NaN if simulation is not active (use real sensor)
+    double getSimulatedValue(uint8_t sensorType);
+    
+    // ============================================================
+    // Manual Value Setters (for runtime adjustment)
+    // ============================================================
+    void setSimPH(double value);
+    void setSimORP(double value);
+    void setSimPSI(double value);
+    void setSimChlLevel(bool active);
+    void setSimPHLevel(bool active);
+    void setSimPoolLevel(bool active);
+    
+    // ============================================================
+    // Status
+    // ============================================================
+    bool isSimulating(uint8_t sensorType);
+    void printStatus();
 
 private:
-    // Simulation level per sensor type
-    // 0 = disabled (use real sensor), 1 = enabled (use simulated value)
-    uint8_t simuPHLevel;
-    uint8_t simuORPLevel;
-    uint8_t simuPSILevel;
-    uint8_t simuCHLLevel;
-
-    // Simulated values (configurable via MQTT or NVS)
-    double simuPHValue;
-    double simuORPValue;
-    double simuPSIValue;
-    double simuCHLValue;
-
-    // Digital input simulation states (pin-based)
-    // Maps KC868-A8 digital pin to simulated state
-    static const uint8_t MAX_SIMU_PINS = 16;
-    int8_t simuDigitalPins[MAX_SIMU_PINS];  // -1 = not simulated, 0/1 = simulated state
-
-    // Preferences key prefix
-    static const char* NVS_NAMESPACE;
-
-public:
-    SensorSimulation();
-
-    // Initialize from NVS (saved settings)
-    void begin();
-
-    // Set simulation level for a sensor type
-    // level: 0 = disabled, 1 = enabled
-    void setSimuLevel(uint8_t sensorType, uint8_t level);
-
-    // Get simulation level for a sensor type
-    uint8_t getSimuLevel(uint8_t sensorType) const;
-
-    // Set simulated value for a sensor
-    void setSimuValue(uint8_t sensorType, double value);
-
-    // Get simulated value for a sensor
-    // Returns the simulated value if simulation is enabled for this sensor,
-    // otherwise returns NAN (not a number) to indicate "use real sensor"
-    double getSimulatedValue(uint8_t sensorType) const;
-
-    // Simulate a digital input pin
-    // pin: KC868-A8 digital pin number
-    // state: 0 or 1
-    void setSimulatedInput(uint8_t pin, uint8_t state);
-
-    // Get simulated digital input state
-    // Returns: 0 or 1 if simulated, -1 if not simulated (use real sensor)
-    int8_t getSimulatedInput(uint8_t pin) const;
-
-    // Check if any simulation is active
-    bool isAnySimulationActive() const;
-
-    // Save current settings to NVS
-    void saveSettings();
-
-    // Load settings from NVS
-    void loadSettings();
-
-    // Reset all simulations to defaults
-    void resetToDefaults();
-
-    // Get sensor type from string (for MQTT commands)
-    static uint8_t sensorTypeFromString(const char* str);
-
-    // Get sensor type as string (for MQTT status)
-    static const char* sensorTypeToString(uint8_t sensorType);
-
-    // Debug: print current simulation state
-    void printStatus() const;
+    // Simulation state
+    bool simulating_chl_level;
+    bool simulating_ph_level;
+    bool simulating_pool_level;
+    bool simulating_ph;
+    bool simulating_orp;
+    bool simulating_psi;
+    
+    // Simulated values
+    double sim_ph_value;
+    double sim_orp_value;
+    double sim_psi_value;
+    bool sim_chl_level;
+    bool sim_ph_level;
+    bool sim_pool_level;
+    
+    // Simulation parameters
+    unsigned long last_update;
+    unsigned long update_interval;
 };
 
 // Global instance

--- a/include/SensorSimulation.h
+++ b/include/SensorSimulation.h
@@ -1,97 +1,107 @@
-/*
- * Sensor Simulation System for ESP32-PoolMaster
- * 
- * Provides individual simulation for each sensor type.
- * Each sensor can be independently enabled/disabled via Config.h flags.
- * 
- * Supported sensors:
- *   - CHL_LEVEL: Chlorine tank level (digital input)
- *   - PH_LEVEL: Acid tank level (digital input)
- *   - POOL_LEVEL: Pool water level (digital input)
- *   - pH: pH sensor (analog via ADS1115)
- *   - ORP: ORP sensor (analog via ADS1115)
- *   - PSI: Pressure sensor (analog via ADS1115)
- * 
- * Usage:
- *   1. Set SIMU_* flags in Config.h to enable simulation for specific sensors
- *   2. Optionally set SIMU_*_VALUE for custom initial values
- *   3. If a sensor is not physically connected, simulation auto-engages
- *   4. Simulation does not affect real sensor logic when disabled
- */
-
 #ifndef SENSOR_SIMULATION_H
 #define SENSOR_SIMULATION_H
 
 #include <Arduino.h>
+#include <Preferences.h>
+
+// Forward declarations for KC868-A8 I/O functions
+// These are implemented in KC868A8_IO.cpp
+void kc868_a8_init();
+uint8_t kc868_a8_digitalRead(uint8_t pin);
+void kc868_a8_digitalWrite(uint8_t pin, uint8_t value);
+
+// ADS1115 multiplexer channel constants (for analog simulation)
+#define ADS1115_MUX_CH0 0x4000  // AIN0
+#define ADS1115_MUX_CH1 0x5000  // AIN1
+#define ADS1115_MUX_CH2 0x6000  // AIN2
+#define ADS1115_MUX_CH3 0x7000  // AIN3
+
+// Default simulated values when no sensor is connected
+#define SIMU_PH_DEFAULT    7.0   // Neutral pH
+#define SIMU_ORP_DEFAULT  700.0  // Typical ORP value (mV)
+#define SIMU_PSI_DEFAULT    1.5  // Typical pool pressure (bar)
+#define SIMU_CHL_DEFAULT  700.0  // Typical chlorine ORP (mV)
 
 class SensorSimulation {
 public:
-    SensorSimulation();
-    
-    // Initialize simulation system
-    void begin();
-    
-    // Update simulation values (called periodically)
-    void loop();
-    
-    // ============================================================
-    // Digital Input Simulation (CHL_LEVEL, PH_LEVEL, POOL_LEVEL)
-    // ============================================================
-    // Returns simulated state for digital inputs
-    // Returns -1 if simulation is not active (use real sensor)
-    int8_t getSimulatedInput(uint8_t pin);
-    
-    // ============================================================
-    // Analog Sensor Simulation (pH, ORP, PSI)
-    // ============================================================
-    // Returns simulated value for analog sensors
-    // Returns NaN if simulation is not active (use real sensor)
-    double getSimulatedValue(uint8_t sensorType);
-    
-    // ============================================================
-    // Manual Value Setters (for runtime adjustment)
-    // ============================================================
-    void setSimPH(double value);
-    void setSimORP(double value);
-    void setSimPSI(double value);
-    void setSimChlLevel(bool active);
-    void setSimPHLevel(bool active);
-    void setSimPoolLevel(bool active);
-    
-    // ============================================================
-    // Status
-    // ============================================================
-    bool isSimulating(uint8_t sensorType);
-    void printStatus();
-
-private:
-    // Simulation state
-    bool simulating_chl_level;
-    bool simulating_ph_level;
-    bool simulating_pool_level;
-    bool simulating_ph;
-    bool simulating_orp;
-    bool simulating_psi;
-    
-    // Simulated values
-    double sim_ph_value;
-    double sim_orp_value;
-    double sim_psi_value;
-    bool sim_chl_level;
-    bool sim_ph_level;
-    bool sim_pool_level;
-    
-    // Simulation parameters
-    unsigned long last_update;
-    unsigned long update_interval;
-    
-    // Sensor type constants
+    // Sensor index constants for analog simulation (used with getSimulatedValue)
     static const uint8_t SENSOR_PH = 0;
     static const uint8_t SENSOR_ORP = 1;
     static const uint8_t SENSOR_PSI = 2;
-    static const uint8_t SENSOR_CHL_LEVEL = 3;
-    static const uint8_t SENSOR_PH_LEVEL = 4;
-    static const uint8_t SENSOR_POOL_LEVEL = 5;
+    static const uint8_t SENSOR_CHL = 3;  // Chlorine (alias for ORP in some configs)
+
+private:
+    // Simulation level per sensor type
+    // 0 = disabled (use real sensor), 1 = enabled (use simulated value)
+    uint8_t simuPHLevel;
+    uint8_t simuORPLevel;
+    uint8_t simuPSILevel;
+    uint8_t simuCHLLevel;
+
+    // Simulated values (configurable via MQTT or NVS)
+    double simuPHValue;
+    double simuORPValue;
+    double simuPSIValue;
+    double simuCHLValue;
+
+    // Digital input simulation states (pin-based)
+    // Maps KC868-A8 digital pin to simulated state
+    static const uint8_t MAX_SIMU_PINS = 16;
+    int8_t simuDigitalPins[MAX_SIMU_PINS];  // -1 = not simulated, 0/1 = simulated state
+
+    // Preferences key prefix
+    static const char* NVS_NAMESPACE;
+
+public:
+    SensorSimulation();
+
+    // Initialize from NVS (saved settings)
+    void begin();
+
+    // Set simulation level for a sensor type
+    // level: 0 = disabled, 1 = enabled
+    void setSimuLevel(uint8_t sensorType, uint8_t level);
+
+    // Get simulation level for a sensor type
+    uint8_t getSimuLevel(uint8_t sensorType) const;
+
+    // Set simulated value for a sensor
+    void setSimuValue(uint8_t sensorType, double value);
+
+    // Get simulated value for a sensor
+    // Returns the simulated value if simulation is enabled for this sensor,
+    // otherwise returns NAN (not a number) to indicate "use real sensor"
+    double getSimulatedValue(uint8_t sensorType) const;
+
+    // Simulate a digital input pin
+    // pin: KC868-A8 digital pin number
+    // state: 0 or 1
+    void setSimulatedInput(uint8_t pin, uint8_t state);
+
+    // Get simulated digital input state
+    // Returns: 0 or 1 if simulated, -1 if not simulated (use real sensor)
+    int8_t getSimulatedInput(uint8_t pin) const;
+
+    // Check if any simulation is active
+    bool isAnySimulationActive() const;
+
+    // Save current settings to NVS
+    void saveSettings();
+
+    // Load settings from NVS
+    void loadSettings();
+
+    // Reset all simulations to defaults
+    void resetToDefaults();
+
+    // Get sensor type from string (for MQTT commands)
+    static uint8_t sensorTypeFromString(const char* str);
+
+    // Get sensor type as string (for MQTT status)
+    static const char* sensorTypeToString(uint8_t sensorType);
+
+    // Debug: print current simulation state
+    void printStatus() const;
 };
 
 // Global instance

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -2,7 +2,7 @@
 #include "Pump.h"
 
 #ifdef KC868_A8
-  #include "SensorSimulation.h"
+  #include "../../include/SensorSimulation.h"
 #endif
 
 //Call this in the main loop, for every loop, as often as possible

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -1,6 +1,10 @@
 #include "Arduino.h"
 #include "Pump.h"
 
+#ifdef KC868_A8
+  #include "SensorSimulation.h"
+#endif
+
 //Call this in the main loop, for every loop, as often as possible
 void Pump::loop()
 {
@@ -89,7 +93,6 @@ bool Pump::Stop()
     UpTime += millis() - LastLoopMillis; 
 
     
-
     return true;
   } else return false;
 }
@@ -113,6 +116,15 @@ bool Pump::TankLevel()
   }
   else
   {
+#ifdef KC868_A8
+    // Check simulation first: if simulation is active for this sensor,
+    // use the simulated value instead of reading the physical pin.
+    // This prevents false "tank full" readings when no sensor is connected.
+    int8_t simVal = SimSensor.getSimulatedInput(tank_level_pin);
+    if (simVal >= 0) {
+        return (simVal == TANK_FULL);
+    }
+#endif
     return (digitalRead(tank_level_pin) == TANK_FULL);
   } 
 }
@@ -146,7 +158,7 @@ double Pump::GetTankUsage()
     double Consumption = flowrate/60.0*MinutesOfUpTime;
     PercentageUsed = Consumption/tankvolume*100.0;
   }
-  return (PercentageUsed);  
+  return (PercentageUsed); 
 }
 
 //Set flow rate of the pump in Liters/hour
@@ -264,11 +276,10 @@ void Pump::SavePreferences(Preferences& prefs, uint8_t pin_id)  {
     prefs.putULong(key, MinUpTime);
   }
 
-void Pump::LoadPreferences(Preferences& prefs, uint8_t pin_id)  {
+void Pump::LoadPreferences(Preferences& prefs, uint8_t pin_id) {
     Relay::LoadPreferences(prefs,pin_id);
 
     char key[15];
-    //uint8_t tmp_pin_id = GetPinId();
 
     snprintf(key, sizeof(key), "d%d_fr", pin_id);
     flowrate = prefs.getDouble(key, flowrate);
@@ -291,4 +302,3 @@ void Pump::LoadPreferences(Preferences& prefs, uint8_t pin_id)  {
     snprintf(key, sizeof(key), "d%d_mi", pin_id);
     MinUpTime = prefs.getULong(key, MinUpTime);
   }
-

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -2,7 +2,7 @@
 #include "Pump.h"
 
 #ifdef KC868_A8
-  #include "../../include/SensorSimulation.h"
+  #include "../../../include/SensorSimulation.h"
 #endif
 
 //Call this in the main loop, for every loop, as often as possible

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -2,6 +2,10 @@
 #include "Config.h"
 #include "PoolMaster.h"
 
+#ifdef KC868_A8
+  #include "SensorSimulation.h"
+#endif
+
 // Setup oneWire instances to communicate with temperature sensors (one bus per sensor)
 static OneWire oneWire_W(ONE_WIRE_BUS_W);
 static OneWire oneWire_A(ONE_WIRE_BUS_A);
@@ -40,8 +44,8 @@ void unlockI2C();
 // 8sps, that means 128ms instead of 125ms. With 16sps, we have 3 + 62.5 < 125ms which is OK.
 // With those settings, we get a value for each channel roughly every second: 9 values asked 
 // (3 per channel), with height values retrieved per second -> 0,89 value per second. The value
-// returned for each channel is the median of the three samples. Then, among the last 
-// 11 samples returned, we take the 5 median ones and compute the mean as consolidated value.
+// returned for each channel is the median of the three samples. Then, among the last 11
+// samples returned, we take the 5 median ones and compute the mean as consolidated value.
 // With the "Loulou74" board, the sampling is different: we sample PSI at 8sps, and pH, Orp at 
 // 4sps each. Filtering and average is then performed as usual to get a new value every second.
 
@@ -251,7 +255,7 @@ void StatusLights(void *pvParameters)
   vTaskDelay(DT7);                                // Scheduling offset 
 
   TickType_t period = PT7;  
-  TickType_t ticktime = xTaskGetTickCount();
+  TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm = 0;
 
   #ifdef CHRONO
@@ -314,7 +318,7 @@ void StatusLights(void *pvParameters)
 
     stack_mon(hwm);
     vTaskDelayUntil(&ticktime,period);
-  }  
+  }
 }
 
 void pHRegulation(void *pvParameters)
@@ -323,7 +327,7 @@ void pHRegulation(void *pvParameters)
   vTaskDelay(DT6);                                // Scheduling offset 
 
   TickType_t period = PT6;  
-  TickType_t ticktime = xTaskGetTickCount();
+  TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm = 0;
 
   #ifdef CHRONO
@@ -392,7 +396,7 @@ void pHRegulation(void *pvParameters)
 
     stack_mon(hwm);
     vTaskDelayUntil(&ticktime,period);
-  }  
+  }
 }
 
 //Orp regulation loop
@@ -402,7 +406,7 @@ void OrpRegulation(void *pvParameters)
   vTaskDelay(DT5);                                // Scheduling offset 
 
   TickType_t period = PT5;  
-  TickType_t ticktime = xTaskGetTickCount();
+  TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm = 0;
 
   #ifdef CHRONO
@@ -501,7 +505,7 @@ void TempInit()
   }  
   if (!sensors_A.getAddress(DS18B20_A, 0)) 
   {
-    Debug.print(DBG_ERROR,"Unable to find address for bus A"); 
+    Debug.print(DBG_ERROR,"Unable to find address for bus A");
     error = true;
   }  
   else {
@@ -537,7 +541,7 @@ void getTemp(void *pvParameters)
   vTaskDelay(DT4);                                // Scheduling offset 
 
   TickType_t period = PT4;  
-  TickType_t ticktime = xTaskGetTickCount();
+  TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm = 0;
 
   #ifdef CHRONO
@@ -587,5 +591,5 @@ void getTemp(void *pvParameters)
 
     stack_mon(hwm);
     vTaskDelayUntil(&ticktime,period);
-  }
+  } 
 }

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -102,6 +102,14 @@ void AnalogPoll(void *pvParameters)
       samples_Orp.add(orp_sensor_value);        // compute average of ORP from last 5 measurements
       PMData.OrpValue = (samples_Orp.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(ORPCALIBCOEFFS0) + PMConfig.get<double>(ORPCALIBCOEFFS1);
 
+#ifdef KC868_A8
+      // Override with simulated values when simulation is active
+      double simPH = SimSensor.getSimulatedValue(SimSensor.SENSOR_PH);
+      if (!isnan(simPH)) PMData.PhValue = simPH;
+      double simORP = SimSensor.getSimulatedValue(SimSensor.SENSOR_ORP);
+      if (!isnan(simORP)) PMData.OrpValue = simORP;
+#endif
+
       Debug.print(DBG_DEBUG,"pH: %5.0f - %4.2f - ORP: %5.0f - %3.0fmV - PSI: %5.0f - %4.2fBar\r",
         ph_sensor_value,PMData.PhValue,orp_sensor_value,PMData.OrpValue,psi_sensor_value,PMData.PSIValue);
     }
@@ -116,6 +124,12 @@ void AnalogPoll(void *pvParameters)
       samples_PSI.add(psi_sensor_value);        // compute average of PSI from last 5 measurements
       PMData.PSIValue = (samples_PSI.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PSICALIBCOEFFS0) + PMConfig.get<double>(PSICALIBCOEFFS1);
       PMData.PSIValue = (PMData.PSIValue < 0)? 0 : PMData.PSIValue;
+
+#ifdef KC868_A8
+      // Override with simulated value when simulation is active
+      double simPSI = SimSensor.getSimulatedValue(SimSensor.SENSOR_PSI);
+      if (!isnan(simPSI)) PMData.PSIValue = simPSI;
+#endif
     }
     unlockI2C();
 
@@ -175,6 +189,26 @@ void AnalogPoll(void *pvParameters)
         samples_Ph.add(ph_sensor_value);          // compute average of pH from center 5 measurements among 11
         PMData.PhValue = (samples_Ph.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PHCALIBCOEFFS0) + PMConfig.get<double>(PHCALIBCOEFFS1);
 
+        //ORP
+        samples_Orp.add(orp_sensor_value);        // compute average of ORP from last 5 measurements
+        PMData.OrpValue = (samples_Orp.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(ORPCALIBCOEFFS0) + PMConfig.get<double>(ORPCALIBCOEFFS1);
+
+        //PSI (water pressure)
+        samples_PSI.add(psi_sensor_value);        // compute average of PSI from last 5 measurements
+        PMData.PSIValue = (samples_PSI.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PSICALIBCOEFFS0) + PMConfig.get<double>(PSICALIBCOEFFS1);
+        PMData.PSIValue = (PMData.PSIValue < 0)? 0 : PMData.PSIValue;
+
+#ifdef KC868_A8
+        // Override with simulated values when simulation is active
+        // This must happen after calibration but before the SIMU PID blocks
+        double simPH = SimSensor.getSimulatedValue(SimSensor.SENSOR_PH);
+        if (!isnan(simPH)) PMData.PhValue = simPH;
+        double simORP = SimSensor.getSimulatedValue(SimSensor.SENSOR_ORP);
+        if (!isnan(simORP)) PMData.OrpValue = simORP;
+        double simPSI = SimSensor.getSimulatedValue(SimSensor.SENSOR_PSI);
+        if (!isnan(simPSI)) PMData.PSIValue = simPSI;
+#endif
+
 #ifdef SIMU
         if(!init_simu){
             if(newpHOutput) {
@@ -201,10 +235,6 @@ void AnalogPoll(void *pvParameters)
         }  
 #endif
 
-        //ORP
-        samples_Orp.add(orp_sensor_value);        // compute average of ORP from last 5 measurements
-        PMData.OrpValue = (samples_Orp.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(ORPCALIBCOEFFS0) + PMConfig.get<double>(ORPCALIBCOEFFS1);
-
 #ifdef SIMU
         if(!init_simu){
             if(newChlOutput) {
@@ -218,11 +248,6 @@ void AnalogPoll(void *pvParameters)
             OrpLastTime = millis();    
         } 
 #endif
-
-        //PSI (water pressure)
-        samples_PSI.add(psi_sensor_value);        // compute average of PSI from last 5 measurements
-        PMData.PSIValue = (samples_PSI.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PSICALIBCOEFFS0) + PMConfig.get<double>(PSICALIBCOEFFS1);
-        PMData.PSIValue = (PMData.PSIValue < 0)? 0 : PMData.PSIValue;
 
         Debug.print(DBG_DEBUG,"pH: %5.0f - %4.2f - ORP: %5.0f - %3.0fmV - PSI: %5.0f - %4.2fBar\r",
             ph_sensor_value,PMData.PhValue,orp_sensor_value,PMData.OrpValue,psi_sensor_value,PMData.PSIValue);


### PR DESCRIPTION
## Problem

Wenn `SIMU_CHL_LEVEL`, `SIMU_PH_LEVEL` und `SIMU_POOL_LEVEL` auf `0` gesetzt sind (Simulation deaktiviert) **und** kein physischer Sensor angeschlossen ist, geben alle 3 Sensoren fälschlicherweise "OK" zurück.

**Ursache:**
- `Pump::TankLevel()` liest direkt `digitalRead(tank_level_pin)` — auf dem KC868-A8 liest der PCF8574 den schwebenden Eingang, der zufällig als `TANK_FULL` (LOW) interpretiert wird
- `AnalogPoll()` liest pH/ORP/PSI direkt vom ADS1115 — auch hier schweben die Eingänge ohne Sensor
- `SensorSimulation` bietet `getSimulatedInput()` / `getSimulatedValue()` an, aber diese werden nirgends im eigentlichen Sensor-Pfad aufgerufen

## Lösung

### 1. `lib/Pump-master/src/Pump.cpp`
- `#include "SensorSimulation.h"` (unter `#ifdef KC868_A8`)
- In `TankLevel()`: Vor `digitalRead()` wird `SimSensor.getSimulatedInput(tank_level_pin)` geprüft
  - Simulation aktiv → simulierter Wert wird zurückgegeben
  - Simulation inaktiv (Return -1) → physischer Pin wird gelesen (Bestehendes Verhalten)

### 2. `src/Loops.cpp`
- In `AnalogPoll()` (beide Branches: `EXT_ADS1115` und non-EXT):
  - Nach Kalibrierung von pH/ORP/PSI wird `SimSensor.getSimulatedValue()` geprüft
  - Simulation aktiv → Simulationswert überschreibt ADC-Wert
  - Simulation inaktiv (Return NaN) → realer ADC-Wert bleibt (Bestehendes Verhalten)

## Verhalten

| SIMU_*_LEVEL | Sensor angeschlossen | Ergebnis |
|:---:|:---:|:---|
| 1 (an) | egal | Simulationswert |
| 0 (aus) | ja | Physischer Wert |
| 0 (aus) | nein | **Korrekt: Kein "OK" mehr** |

## Test

1. Kompilieren mit `pio run -e kc868_a8`
2. `SIMU_CHL_LEVEL=0, SIMU_PH_LEVEL=0, SIMU_POOL_LEVEL=0` — alle Sensoren sollten jetzt "nicht OK" sein, wenn kein Sensor angeschlossen ist
3. `SIMU_CHL_LEVEL=1` setzen → Chlor-Sensor sollte "OK" (simuliert) zeigen
4. Physische Sensoren anschließen → Werte werden korrekt gelesen

## Hinweis

Dies ist ein Fork — Änderungen betreffen nur Hubert2208/ESP32-PoolMaster, nicht das Upstream-Projekt.