### PR TITLE
fix: SIMU-PID-Feedback nur noch mit per-Sensor-Flags steuern

### DIFF
--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -209,7 +209,7 @@ void AnalogPoll(void *pvParameters)
         if (!isnan(simPSI)) PMData.PSIValue = simPSI;
 #endif
 
-#ifdef SIMU
+#if defined(SIMU) && SIMU_PH
         if(!init_simu){
             if(newpHOutput) {
                 pHTab[iw] = PMData.PhPIDOutput;
@@ -235,7 +235,7 @@ void AnalogPoll(void *pvParameters)
         }  
 #endif
 
-#ifdef SIMU
+#if defined(SIMU) && SIMU_ORP
         if(!init_simu){
             if(newChlOutput) {
             ChlTab[jw] = PMData.OrpPIDOutput;
@@ -378,11 +378,11 @@ void pHRegulation(void *pvParameters)
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f, %13.9f, %13.9f, %17.9f",PMData.PhPIDOutput,PMData.PhValue,PMData.Ph_SetPoint,PMConfig.get<double>(PH_KP));
             if(PMData.PhPIDOutput < (double)30000.) PMData.PhPIDOutput = 0.;
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f",PMData.PhPIDOutput);
-        #ifdef SIMU
+        #if defined(SIMU) && SIMU_PH
             newpHOutput = true;
         #endif            
           }
-        #ifdef SIMU
+        #if defined(SIMU) && SIMU_PH
           else newpHOutput = false;
         #endif    
           /************************************************
@@ -456,11 +456,11 @@ void OrpRegulation(void *pvParameters)
           Debug.print(DBG_INFO,"ORP regulation: %10.2f, %13.9f, %12.9f, %17.9f",PMData.OrpPIDOutput,PMData.OrpValue,PMData.Orp_SetPoint,PMConfig.get<double>(ORP_KP));
           if(PMData.OrpPIDOutput < (double)30000.) PMData.OrpPIDOutput = 0.;    
             Debug.print(DBG_INFO,"Orp regulation: %10.2f",PMData.OrpPIDOutput);
-      #ifdef SIMU
+      #if defined(SIMU) && SIMU_ORP
             newChlOutput = true;
       #endif      
           }
-      #ifdef SIMU
+      #if defined(SIMU) && SIMU_ORP
           else newChlOutput = false;
       #endif    
         /************************************************


### PR DESCRIPTION
## Problem

Die `#ifdef SIMU`-Blöcke in `AnalogPoll()` und den Regulation-Schleifen (`pHRegulation`, `OrpRegulation`) liefen **immer** wenn `SIMU` definiert war — unabhängig von `SIMU_PH` / `SIMU_ORP`.

Das führte dazu, dass die simulierten Werte (7.2 pH, 720 mV ORP) durch PID-Feedback-Berechnungen **überschrieben** wurden und langsam zum Sollwert konvergierten.

## Ursache

```
// AnalogPoll - IMMER aktiv wenn SIMU definiert:
#ifdef SIMU                    // ← Prüft nur SIMU, nicht SIMU_PH
    PMData.PhValue = pHLastValue + pHCumul/4500000.*(...)
#endif
```

`SIMU_PH=1` steuert nur den **initiaten** Simulationswert, aber das PID-Feedback in AnalogPoll lief unabhängig davon.

## Lösung

Alle 6 `#ifdef SIMU`-Blöcke mit per-Sensor-Flags versehen:

| Datei | Stelle | Von | Zu |
|:---|:---|:---|:---|
| Loops.cpp:212 | AnalogPoll pH | `#ifdef SIMU` | `#if defined(SIMU) && SIMU_PH` |
| Loops.cpp:238 | AnalogPoll ORP | `#ifdef SIMU` | `#if defined(SIMU) && SIMU_ORP` |
| Loops.cpp:381 | pHRegulation | `#ifdef SIMU` | `#if defined(SIMU) && SIMU_PH` |
| Loops.cpp:385 | pHRegulation | `#ifdef SIMU` | `#if defined(SIMU) && SIMU_PH` |
| Loops.cpp:459 | OrpRegulation | `#ifdef SIMU` | `#if defined(SIMU) && SIMU_ORP` |
| Loops.cpp:463 | OrpRegulation | `#ifdef SIMU` | `#if defined(SIMU) && SIMU_ORP` |

## Verhalten nach Fix

| SIMU | SIMU_PH | SIMU_ORP | pH-Verhalten | ORP-Verhalten |
|:---:|:---:|:---:|:---|:---|
| definiert | 1 | 1 | Simuliert + PID-Feedback | Simuliert + PID-Feedback |
| definiert | 1 | 0 | Simuliert + PID-Feedback | Simulierter Anfangswert, **kein** Feedback |
| definiert | 0 | 1 | Simulierter Anfangswert, **kein** Feedback | Simuliert + PID-Feedback |
| definiert | 0 | 0 | Nur SimSensor (kein PID) | Nur SimSensor (kein PID) |
| nicht def. | egal | egal | Realer ADC-Wert | Realer ADC-Wert |

## Test

1. `SIMU_PH=0, SIMU_ORP=0` → pH/ORP bleiben konstant (kein Drift)
2. `SIMU_PH=1, SIMU_PH=1` → pH/ORP konvergieren zum Soll (PID-Feedback aktiv)
3. Kombination testieren (nur pH simu, ORP real)