### PR TITLE
fix: Force all relays OFF after device initialization

### DIFF
--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -354,6 +354,16 @@ void setup()
   PoolDeviceManager.InitDevicesInterlock();
   PoolDeviceManager.Begin();
 
+#ifdef KC868_A8
+  // Force all relays OFF after device initialization
+  // Pump constructor defaults to ACTIVE_LOW, but KC868-A8 hardware is ACTIVE_HIGH
+  // PIN::Begin() would set relays ON due to this mismatch — fix it here
+  for (uint8_t i = 0; i < 8; i++) {
+    KC868.setRelay(i, false);
+  }
+  Serial.println("[KC868-A8] All relays forced OFF after init");
+#endif
+
   // Initialize watch-dog
   esp_task_wdt_init(WDT_TIMEOUT, true);
 


### PR DESCRIPTION
## Problem

Beim Start des Programms wurden die Relais nicht zuverlässig in den Zustand AUS versetzt.

**Ursache:** Die `Pump`-Klasse hat `ACTIVE_LOW` als Default-Wert für `active_level`. Die KC868-A8 Hardware nutzt jedoch `ACTIVE_HIGH` (HIGH = Relay EIN).

Wenn `PoolDeviceManager.Begin()` `PIN::Begin()` für jedes Gerät aufruft, wird `digitalWrite(pin, !active_level)` aufgerufen. Da `active_level = 0` (ACTIVE_LOW), wird `!0 = 1` (HIGH) geschrieben → Relais EIN statt AUS.

## Lösung

Nach `PoolDeviceManager.Begin()` werden alle 8 Relais explizit auf AUS gesetzt:

```cpp
#ifdef KC868_A8
  for (uint8_t i = 0; i < 8; i++) {
    KC868.setRelay(i, false);
  }
#endif
```

## Test

1. ESP32 neustarten
2. Alle Relais sollten AUS sein (kein Klicken, keine Spannung an den Ausgängen)
3. Filtration starten → Relais 1 EIN
4. Filtration stoppen → Relais 1 AUS