### PR TITLE
feat(sensor-sim): PID-Feedback-Loop für simulierte pH/ORP-Sensoren (v2)

### DIFF
--- a/include/SensorSimulation.h
+++ b/include/SensorSimulation.h
@@ -40,14 +40,12 @@ public:
     static const uint8_t SENSOR_POOL_LEVEL = 5;
 
     // Default simulation rate constants
-    // KPH:  pH change per ms of PID output per second
-    //   At 100% output over 1h (3,600,000 ms): 0.0000028 * 3,600,000 = ~0.10 pH
-    //   Suitable for a ~50m3 pool with 1.5 L/h acid pump
-    static constexpr double SIM_KPH  = 0.0000028;
-    // KORP: ORP change per ms of PID output per second
-    //   At 100% output over 1h (3,600,000 ms): 0.00139 * 3,600,000 = ~50 mV
-    //   Suitable for a ~50m3 pool with 1.5 L/h chlorine pump
-    static constexpr double SIM_KORP = 0.00139;
+    // At 100% PID output:
+    //   SIM_KPH=0.0001  → pH changes ~0.5/h (visible in ~2 min)
+    //   SIM_KORP=0.05   → ORP changes ~225 mV/h (visible in ~2 min)
+    // Adjust these in Config.h or here to match your pool size & pump flow rate.
+    static constexpr double SIM_KPH  = 0.0001;
+    static constexpr double SIM_KORP = 0.05;
 
     SensorSimulation();
     

--- a/include/SensorSimulation.h
+++ b/include/SensorSimulation.h
@@ -12,6 +12,11 @@
  *   - ORP: ORP sensor (analog via ADS1115)
  *   - PSI: Pressure sensor (analog via ADS1115)
  * 
+ * PID Feedback:
+ *   When simulation is active, the PID output drives the simulated
+ *   sensor values. The acid pump decreases pH, the chlorine pump
+ *   increases ORP. Rates are configurable via SIM_KPH and SIM_KORP.
+ * 
  * Usage:
  *   1. Set SIMU_* flags in Config.h to enable simulation for specific sensors
  *   2. Optionally set SIMU_*_VALUE for custom initial values
@@ -34,13 +39,31 @@ public:
     static const uint8_t SENSOR_PH_LEVEL = 4;
     static const uint8_t SENSOR_POOL_LEVEL = 5;
 
+    // Default simulation rate constants
+    // KPH:  pH change per ms of PID output per second
+    //   At 100% output over 1h (3,600,000 ms): 0.0000028 * 3,600,000 = ~0.10 pH
+    //   Suitable for a ~50m3 pool with 1.5 L/h acid pump
+    static constexpr double SIM_KPH  = 0.0000028;
+    // KORP: ORP change per ms of PID output per second
+    //   At 100% output over 1h (3,600,000 ms): 0.00139 * 3,600,000 = ~50 mV
+    //   Suitable for a ~50m3 pool with 1.5 L/h chlorine pump
+    static constexpr double SIM_KORP = 0.00139;
+
     SensorSimulation();
     
     // Initialize simulation system
     void begin();
     
-    // Update simulation values (called periodically)
+    // Update simulation values (called periodically in AnalogPoll)
+    // Computes new pH/ORP from PID outputs and returns simulated values
     void loop();
+    
+    // ============================================================
+    // PID Feedback Interface
+    // ============================================================
+    // Called by AnalogPoll to pass current PID outputs to the simulation.
+    // The simulation uses these to drive the simulated sensor values.
+    void setPIDOutputs(double phOutput, double orpOutput);
     
     // ============================================================
     // Digital Input Simulation (CHL_LEVEL, PH_LEVEL, POOL_LEVEL)
@@ -88,6 +111,10 @@ private:
     bool sim_chl_level;
     bool sim_ph_level;
     bool sim_pool_level;
+    
+    // PID feedback state
+    double last_ph_output;
+    double last_orp_output;
     
     // Simulation parameters
     unsigned long last_update;

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -40,7 +40,7 @@ void unlockI2C();
 //Update loop for ADS1115 measurements
 // Some explanations: The sampling rate is set to 16sps in order to be sure that 
 // every 125ms (which is the period of the task) there is a sample available. As it takes 3ms to
-// update and restart the ADC, the whole loop takes a minimum of 3 + 1/SPS ms. If SPS was set to 
+// update and restart the ADC, the whole loop takes a minimum of 3 + 1/SPS ms. If SPS was set to
 // 8sps, that means 128ms instead of 125ms. With 16sps, we have 3 + 62.5 < 125ms which is OK.
 // With those settings, we get a value for each channel roughly every second: 9 values asked 
 // (3 per channel), with height values retrieved per second -> 0,89 value per second. The value
@@ -103,7 +103,9 @@ void AnalogPoll(void *pvParameters)
       PMData.OrpValue = (samples_Orp.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(ORPCALIBCOEFFS0) + PMConfig.get<double>(ORPCALIBCOEFFS1);
 
 #ifdef KC868_A8
-      // Override with simulated values when simulation is active
+      // Update PID feedback simulation and override with simulated values
+      SimSensor.loop();  // Compute new simulated values from PID outputs
+      SimSensor.setPIDOutputs(PMData.PhPIDOutput, PMData.OrpPIDOutput);
       double simPH = SimSensor.getSimulatedValue(SimSensor.SENSOR_PH);
       if (!isnan(simPH)) PMData.PhValue = simPH;
       double simORP = SimSensor.getSimulatedValue(SimSensor.SENSOR_ORP);
@@ -199,8 +201,9 @@ void AnalogPoll(void *pvParameters)
         PMData.PSIValue = (PMData.PSIValue < 0)? 0 : PMData.PSIValue;
 
 #ifdef KC868_A8
-        // Override with simulated values when simulation is active
-        // This must happen after calibration but before the SIMU PID blocks
+        // Update PID feedback simulation and override with simulated values
+        SimSensor.loop();  // Compute new simulated values from PID outputs
+        SimSensor.setPIDOutputs(PMData.PhPIDOutput, PMData.OrpPIDOutput);
         double simPH = SimSensor.getSimulatedValue(SimSensor.SENSOR_PH);
         if (!isnan(simPH)) PMData.PhValue = simPH;
         double simORP = SimSensor.getSimulatedValue(SimSensor.SENSOR_ORP);

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -40,7 +40,7 @@ void unlockI2C();
 //Update loop for ADS1115 measurements
 // Some explanations: The sampling rate is set to 16sps in order to be sure that 
 // every 125ms (which is the period of the task) there is a sample available. As it takes 3ms to
-// update and restart the ADC, the whole loop takes a minimum of 3 + 1/SPS ms. If SPS was set to
+// update and restart the ADC, the whole loop takes a minimum of 3 + 1/SPS ms. If SPS was set to 
 // 8sps, that means 128ms instead of 125ms. With 16sps, we have 3 + 62.5 < 125ms which is OK.
 // With those settings, we get a value for each channel roughly every second: 9 values asked 
 // (3 per channel), with height values retrieved per second -> 0,89 value per second. The value
@@ -104,8 +104,9 @@ void AnalogPoll(void *pvParameters)
 
 #ifdef KC868_A8
       // Update PID feedback simulation and override with simulated values
-      SimSensor.loop();  // Compute new simulated values from PID outputs
+      // IMPORTANT: setPIDOutputs() BEFORE loop() so current PID output is used immediately
       SimSensor.setPIDOutputs(PMData.PhPIDOutput, PMData.OrpPIDOutput);
+      SimSensor.loop();  // Compute new simulated values from PID outputs
       double simPH = SimSensor.getSimulatedValue(SimSensor.SENSOR_PH);
       if (!isnan(simPH)) PMData.PhValue = simPH;
       double simORP = SimSensor.getSimulatedValue(SimSensor.SENSOR_ORP);
@@ -202,8 +203,9 @@ void AnalogPoll(void *pvParameters)
 
 #ifdef KC868_A8
         // Update PID feedback simulation and override with simulated values
-        SimSensor.loop();  // Compute new simulated values from PID outputs
+        // IMPORTANT: setPIDOutputs() BEFORE loop() so current PID output is used immediately
         SimSensor.setPIDOutputs(PMData.PhPIDOutput, PMData.OrpPIDOutput);
+        SimSensor.loop();  // Compute new simulated values from PID outputs
         double simPH = SimSensor.getSimulatedValue(SimSensor.SENSOR_PH);
         if (!isnan(simPH)) PMData.PhValue = simPH;
         double simORP = SimSensor.getSimulatedValue(SimSensor.SENSOR_ORP);

--- a/src/SensorSimulation.cpp
+++ b/src/SensorSimulation.cpp
@@ -27,6 +27,8 @@ SensorSimulation::SensorSimulation()
       sim_chl_level(SIMU_CHL_LEVEL_VALUE),
       sim_ph_level(SIMU_PH_LEVEL_VALUE),
       sim_pool_level(SIMU_POOL_LEVEL_VALUE),
+      last_ph_output(0.0),
+      last_orp_output(0.0),
       last_update(0),
       update_interval(1000) {  // Update every second
 }
@@ -62,11 +64,46 @@ void SensorSimulation::begin() {
 
 void SensorSimulation::loop() {
     unsigned long now = millis();
-    if (now - last_update < update_interval) return;
+    double dt_seconds = (now - last_update) / 1000.0;
     last_update = now;
     
-    // Optional: Add dynamic simulation behavior here
-    // For example, slowly ramp values or add noise
+    // Skip first iteration (dt would be wrong)
+    if (dt_seconds <= 0.0 || dt_seconds > 10.0) return;
+    
+    // ============================================================
+    // pH Simulation (PID Feedback)
+    // ============================================================
+    // PhPID_DIRECTION is REVERSE:
+    //   When pH > setpoint: PID output high -> acid pump runs -> pH decreases
+    //   When pH < setpoint: PID output low/zero -> no acid -> pH stable
+    //   Model: dpH/dt = -KPH * PID_output * dt
+    if (simulating_ph) {
+        double phDelta = -SIM_KPH * last_ph_output * dt_seconds;
+        sim_ph_value += phDelta;
+        // Clamp pH to valid range [0.0, 14.0]
+        if (sim_ph_value < 0.0) sim_ph_value = 0.0;
+        if (sim_ph_value > 14.0) sim_ph_value = 14.0;
+    }
+    
+    // ============================================================
+    // ORP Simulation (PID Feedback)
+    // ============================================================
+    // OrpPID_DIRECTION is DIRECT:
+    //   When ORP < setpoint: PID output high -> chlorine pump runs -> ORP increases
+    //   When ORP > setpoint: PID output low/zero -> no chlorine -> ORP stable
+    //   Model: dORP/dt = KORP * PID_output * dt
+    if (simulating_orp) {
+        double orpDelta = SIM_KORP * last_orp_output * dt_seconds;
+        sim_orp_value += orpDelta;
+        // Clamp ORP to valid range [0, 1000] mV
+        if (sim_orp_value < 0.0) sim_orp_value = 0.0;
+        if (sim_orp_value > 1000.0) sim_orp_value = 1000.0;
+    }
+}
+
+void SensorSimulation::setPIDOutputs(double phOutput, double orpOutput) {
+    last_ph_output = phOutput;
+    last_orp_output = orpOutput;
 }
 
 int8_t SensorSimulation::getSimulatedInput(uint8_t pin) {
@@ -155,10 +192,10 @@ void SensorSimulation::printStatus() {
     Serial.printf("  POOL_LEVEL: %s (value: %s)\n",
         simulating_pool_level ? "SIM" : "REAL",
         sim_pool_level ? "HIGH" : "LOW");
-    Serial.printf("  pH: %s (value: %.2f)\n",
-        simulating_ph ? "SIM" : "REAL", sim_ph_value);
-    Serial.printf("  ORP: %s (value: %.1f)\n",
-        simulating_orp ? "SIM" : "REAL", sim_orp_value);
+    Serial.printf("  pH: %s (value: %.2f, lastPID: %.0f)\n",
+        simulating_ph ? "SIM" : "REAL", sim_ph_value, last_ph_output);
+    Serial.printf("  ORP: %s (value: %.1f, lastPID: %.0f)\n",
+        simulating_orp ? "SIM" : "REAL", sim_orp_value, last_orp_output);
     Serial.printf("  PSI: %s (value: %.3f)\n",
         simulating_psi ? "SIM" : "REAL", sim_psi_value);
 }

--- a/src/SensorSimulation.cpp
+++ b/src/SensorSimulation.cpp
@@ -78,7 +78,8 @@ void SensorSimulation::loop() {
         sim_ph_value += phDelta;
         if (sim_ph_value < 0.0) sim_ph_value = 0.0;
         if (sim_ph_value > 14.0) sim_ph_value = 14.0;
-        Debug.print(DBG_INFO, "[Sim] pH: %.3f (PID: %.0f, dt: %.3fs, delta: %.6f)",
+        // Use Serial.printf directly - Debug.print is suppressed at CORE_DEBUG_LEVEL=0
+        Serial.printf("[Sim] pH: %.3f PID: %.0f dt: %.3fs delta: %.6f\n",
             sim_ph_value, last_ph_output, dt_seconds, phDelta);
     }
     
@@ -90,7 +91,7 @@ void SensorSimulation::loop() {
         sim_orp_value += orpDelta;
         if (sim_orp_value < 0.0) sim_orp_value = 0.0;
         if (sim_orp_value > 1000.0) sim_orp_value = 1000.0;
-        Debug.print(DBG_INFO, "[Sim] ORP: %.1f (PID: %.0f, dt: %.3fs, delta: %.3f)",
+        Serial.printf("[Sim] ORP: %.1f PID: %.0f dt: %.3fs delta: %.3f\n",
             sim_orp_value, last_orp_output, dt_seconds, orpDelta);
     }
 }

--- a/src/SensorSimulation.cpp
+++ b/src/SensorSimulation.cpp
@@ -73,31 +73,25 @@ void SensorSimulation::loop() {
     // ============================================================
     // pH Simulation (PID Feedback)
     // ============================================================
-    // PhPID_DIRECTION is REVERSE:
-    //   When pH > setpoint: PID output high -> acid pump runs -> pH decreases
-    //   When pH < setpoint: PID output low/zero -> no acid -> pH stable
-    //   Model: dpH/dt = -KPH * PID_output * dt
     if (simulating_ph) {
         double phDelta = -SIM_KPH * last_ph_output * dt_seconds;
         sim_ph_value += phDelta;
-        // Clamp pH to valid range [0.0, 14.0]
         if (sim_ph_value < 0.0) sim_ph_value = 0.0;
         if (sim_ph_value > 14.0) sim_ph_value = 14.0;
+        Debug.print(DBG_INFO, "[Sim] pH: %.3f (PID: %.0f, dt: %.3fs, delta: %.6f)",
+            sim_ph_value, last_ph_output, dt_seconds, phDelta);
     }
     
     // ============================================================
     // ORP Simulation (PID Feedback)
     // ============================================================
-    // OrpPID_DIRECTION is DIRECT:
-    //   When ORP < setpoint: PID output high -> chlorine pump runs -> ORP increases
-    //   When ORP > setpoint: PID output low/zero -> no chlorine -> ORP stable
-    //   Model: dORP/dt = KORP * PID_output * dt
     if (simulating_orp) {
         double orpDelta = SIM_KORP * last_orp_output * dt_seconds;
         sim_orp_value += orpDelta;
-        // Clamp ORP to valid range [0, 1000] mV
         if (sim_orp_value < 0.0) sim_orp_value = 0.0;
         if (sim_orp_value > 1000.0) sim_orp_value = 1000.0;
+        Debug.print(DBG_INFO, "[Sim] ORP: %.1f (PID: %.0f, dt: %.3fs, delta: %.3f)",
+            sim_orp_value, last_orp_output, dt_seconds, orpDelta);
     }
 }
 


### PR DESCRIPTION
## Problem

PID-Regelung für pH und ORP hatte mit simulierten Sensoren keinen Effekt. `SensorSimulation` liefert fixe Werte (pH=7.2, ORP=720), unabhängig vom PID-Output.

## Lösung

PID-Feedback-Loop in `SensorSimulation`:

1. **`SensorSimulation.h`** — `setPIDOutputs()`, `loop()`, `SIM_KPH`/`SIM_KORP`
2. **`SensorSimulation.cpp`** — Feedback-Logik: pH sinkt bei Säurepumpen-Output, ORP steigt bei Chlor
3. **`Loops.cpp`** — `SimSensor.loop()` + `setPIDOutputs()` in AnalogPoll

## Feedback-Kette

```
PID.compute() → Output → SimSensor.setPIDOutputs()
                              ↓
                       SimSensor.loop() berechnet
                       neuen pH/ORP basierend auf Output
                              ↓
                       PMData.PhValue = neuer Wert
                              ↓
                       Nächster PID-Zyklus sieht Änderung
```

## Testing

1. `PHAUTOMODE` und `ORPAUTOMODE` auf `true` setzen
2. Filtrationspumpe muss laufen
3. pH-Sollwert z.B. auf 7.0 setzen (Simulation startet bei 7.2)
4. PID sollte aktiv werden → Pumpe läuft → pH sinkt langsam