### PR TITLE
feat: pH/ORP Feedback-Loop für simulierte Sensoren

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -62,6 +62,41 @@
 #define SIMU_PH_LEVEL_VALUE   1     // Default: HIGH (tank not empty)
 #define SIMU_POOL_LEVEL_VALUE 1     // Default: HIGH (pool level OK)
 
+// ============================================================
+// SIMULATION FEEDBACK PARAMETERS
+// ============================================================
+// These parameters control how simulated sensor values change
+// when the corresponding pump is active (PID feedback loop).
+// ============================================================
+
+// pH Feedback: Amount pH changes per second when acid pump is running
+// Negative value: pH decreases when pump is ON (adding acid)
+// Example: 0.001 = pH drops 0.06 units per minute
+#ifndef SIM_KPH
+  #define SIM_KPH           0.001   // pH units per second
+#endif
+
+// ORP Feedback: Amount ORP changes per second when chlorine pump is running
+// Positive value: ORP increases when pump is ON (adding chlorine)
+// Example: 0.5 = ORP rises 30 units per minute
+#ifndef SIM_KORP
+  #define SIM_KORP          0.5     // ORP units per second
+#endif
+
+// Simulation limits (prevent values from going out of realistic range)
+#ifndef SIM_PH_MIN
+  #define SIM_PH_MIN        6.0     // Minimum pH value
+#endif
+#ifndef SIM_PH_MAX
+  #define SIM_PH_MAX        8.5     // Maximum pH value
+#endif
+#ifndef SIM_ORP_MIN
+  #define SIM_ORP_MIN       600.0   // Minimum ORP value (mV)
+#endif
+#ifndef SIM_ORP_MAX
+  #define SIM_ORP_MAX       900.0   // Maximum ORP value (mV)
+#endif
+
 // If you need to force network parameters (configuration with no screen)
 #define FORCE_NETWORK_PARAMS
 #ifdef FORCE_NETWORK_PARAMS

--- a/include/Config.h
+++ b/include/Config.h
@@ -69,10 +69,10 @@
 // when the corresponding pump is active (PID feedback loop).
 //
 // Physics of a real pool:
-//   pH:  Acid pump ON  → pH DECREASES (SIM_KPH is negative)
-//        Pump OFF      → pH INCREASES naturally (CO2 outgassing)
-//   ORP: Chlorine pump ON → ORP INCREASES (SIM_KORP is positive)
-//        Pump OFF        → ORP DECREASES naturally (chlorine degradation)
+//   pH:  Acid pump ON  -> pH DECREASES (SIM_KPH is negative)
+//        Pump OFF      -> pH INCREASES naturally (CO2 outgassing)
+//   ORP: Chlorine pump ON -> ORP INCREASES (SIM_KORP is positive)
+//        Pump OFF        -> ORP DECREASES naturally (chlorine degradation)
 // ============================================================
 
 // pH Feedback: Amount pH changes per second when acid pump is running
@@ -218,3 +218,93 @@
 
 // Task TimeOut before reboot
 #define WDT_TIMEOUT     10
+
+// Delay when instructed to reboot
+#define REBOOT_DELAY  10000
+
+// Server port
+//#define SERVER_PORT 8060
+
+//OTA port
+#define OTA_PORT    8063
+
+//12bits (0,06°C) temperature sensors resolution
+#define TEMPERATURE_RESOLUTION 12
+
+// Time to wait for Wifi to connect. If not connected resume startup without network connection
+#define WIFI_TIMEOUT  10000
+
+//MQTT stuff including local broker/server IP address, login and pwd
+//------------------------------------------------------------------
+
+//interval (in millisec) between MQTT publishement of measurement data
+// can be configured at runtime
+#define PUBLISHINTERVAL 30000
+
+#define CONFIG_NVS_NAME "MasterConfig" // NVS namespace for configuration storage
+
+// Default values if nothing better is recorded at runtime
+#define POOLTOPIC "Home/Pool/"
+#define MQTTID "PoolMaster"
+// ElegantOTA Config
+//#define ELEGANT_OTA
+
+#ifdef ELEGANT_OTA
+  //#define ELEGANT_OTA_AUTH
+  //#define ELEGANT_OTA_USERNAME  "username"
+  //#define ELEGANT_OTA_PASSWORD  "password"
+#endif
+// Robot pump timing
+#define ROBOT_DELAY 60     // Robot start delay after filtration in mn
+#define ROBOT_DURATION 90  // Robot cleaning duration
+
+#define SWG_MODE_ADJUST 0   // Adjust SWG production time according to the pool ORP
+#define SWG_MODE_FIXED 1    // Fixed time for SWG production (in hours)
+
+//Display timeout before blanking
+//-------------------------------
+//#define TFT_SLEEP 60000L  // Moved to Nextion Library
+
+// Loop tasks scheduling parameters
+//---------------------------------
+// T1: AnalogPoll
+// T2: PoolServer
+// T3: PoolMaster
+// T4: getTemp
+// T5: OrpRegulation
+// T6: pHRegulation
+// T7: StatusLights
+// T8: PublishMeasures
+// T9: PublishSettings 
+// T10: Nextion Screen Refresh On (/2 when screen on, /4 if menu page for faster refresh)
+// T11: Every 2 minutes, statistics recording, MQTT and NTP reconnects
+
+//Periods 
+// Task9 period is initialized with PUBLISHINTERVAL and can be changed dynamically
+#define PT1 125
+#define PT2 500
+#define PT3 500
+#define PT4 1000 / (1 << (12 - TEMPERATURE_RESOLUTION))
+#define PT5 1000
+#define PT6 1000
+#define PT7 3000
+#define PT8 30000 //Unused, stored as config parameter and can be modified at runtime
+#define PT9 1000
+#define PT10 1000
+#define PT11 120000 // Run once every 2 minutes
+
+
+//Start offsets to spread tasks along time
+// Task1 has no delay
+#define DT2 190/portTICK_PERIOD_MS
+#define DT3 310/portTICK_PERIOD_MS
+#define DT4 440/portTICK_PERIOD_MS
+#define DT5 560/portTICK_PERIOD_MS
+#define DT6 920/portTICK_PERIOD_MS
+#define DT7 100/portTICK_PERIOD_MS
+#define DT8 570/portTICK_PERIOD_MS
+#define DT9 940/portTICK_PERIOD_MS
+#define DT10 50/portTICK_PERIOD_MS
+#define DT11 2000/portTICK_PERIOD_MS
+
+//#define CHRONO                    // Activate tasks timings traces for profiling

--- a/include/Config.h
+++ b/include/Config.h
@@ -58,8 +58,8 @@
 #define SIMU_PH_VALUE       7.2     // Default simulated pH
 #define SIMU_ORP_VALUE      720.0   // Default simulated ORP (mV)
 #define SIMU_PSI_VALUE      0.1    // Default simulated pressure (bar)
-#define SIMU_CHL_LEVEL_VALUE  1     // Default: HIGH (tank not empty)
-#define SIMU_PH_LEVEL_VALUE   1     // Default: HIGH (tank not empty)
+#define SIMU_CHL_LEVEL_VALUE  0     // Default: Low (tank not empty)
+#define SIMU_PH_LEVEL_VALUE   0     // Default: Low (tank not empty)
 #define SIMU_POOL_LEVEL_VALUE 1     // Default: HIGH (pool level OK)
 
 // ============================================================

--- a/include/Config.h
+++ b/include/Config.h
@@ -67,20 +67,40 @@
 // ============================================================
 // These parameters control how simulated sensor values change
 // when the corresponding pump is active (PID feedback loop).
+//
+// Physics of a real pool:
+//   pH:  Acid pump ON  → pH DECREASES (SIM_KPH is negative)
+//        Pump OFF      → pH INCREASES naturally (CO2 outgassing)
+//   ORP: Chlorine pump ON → ORP INCREASES (SIM_KORP is positive)
+//        Pump OFF        → ORP DECREASES naturally (chlorine degradation)
 // ============================================================
 
 // pH Feedback: Amount pH changes per second when acid pump is running
 // Negative value: pH decreases when pump is ON (adding acid)
-// Example: 0.001 = pH drops 0.06 units per minute
+// Example: -0.001 = pH drops 0.06 units per minute
 #ifndef SIM_KPH
-  #define SIM_KPH           0.001   // pH units per second
+  #define SIM_KPH           -0.001  // pH units per second (negative = drops)
+#endif
+
+// pH Natural Drift: Amount pH increases per second when pump is OFF
+// Positive value: pH rises naturally (CO2 outgassing, alkalinity)
+// Should be slower than pump effect to allow PID control
+#ifndef SIM_KPH_NATURAL
+  #define SIM_KPH_NATURAL   0.0001  // pH units per second (positive = rises)
 #endif
 
 // ORP Feedback: Amount ORP changes per second when chlorine pump is running
 // Positive value: ORP increases when pump is ON (adding chlorine)
 // Example: 0.5 = ORP rises 30 units per minute
 #ifndef SIM_KORP
-  #define SIM_KORP          0.5     // ORP units per second
+  #define SIM_KORP          0.5     // ORP units per second (positive = rises)
+#endif
+
+// ORP Natural Drift: Amount ORP decreases per second when pump is OFF
+// Positive value: ORP falls naturally (chlorine degradation)
+// Should be slower than pump effect to allow PID control
+#ifndef SIM_KORP_NATURAL
+  #define SIM_KORP_NATURAL  0.05    // ORP units per second (positive = falls)
 #endif
 
 // Simulation limits (prevent values from going out of realistic range)
@@ -198,93 +218,3 @@
 
 // Task TimeOut before reboot
 #define WDT_TIMEOUT     10
-
-// Delay when instructed to reboot
-#define REBOOT_DELAY  10000
-
-// Server port
-//#define SERVER_PORT 8060
-
-//OTA port
-#define OTA_PORT    8063
-
-//12bits (0,06°C) temperature sensors resolution
-#define TEMPERATURE_RESOLUTION 12
-
-// Time to wait for Wifi to connect. If not connected resume startup without network connection
-#define WIFI_TIMEOUT  10000
-
-//MQTT stuff including local broker/server IP address, login and pwd
-//------------------------------------------------------------------
-
-//interval (in millisec) between MQTT publishement of measurement data
-// can be configured at runtime
-#define PUBLISHINTERVAL 30000
-
-#define CONFIG_NVS_NAME "MasterConfig" // NVS namespace for configuration storage
-
-// Default values if nothing better is recorded at runtime
-#define POOLTOPIC "Home/Pool/"
-#define MQTTID "PoolMaster"
-// ElegantOTA Config
-//#define ELEGANT_OTA
-
-#ifdef ELEGANT_OTA
-  //#define ELEGANT_OTA_AUTH
-  //#define ELEGANT_OTA_USERNAME  "username"
-  //#define ELEGANT_OTA_PASSWORD  "password"
-#endif
-// Robot pump timing
-#define ROBOT_DELAY 60     // Robot start delay after filtration in mn
-#define ROBOT_DURATION 90  // Robot cleaning duration
-
-#define SWG_MODE_ADJUST 0   // Adjust SWG production time according to the pool ORP
-#define SWG_MODE_FIXED 1    // Fixed time for SWG production (in hours)
-
-//Display timeout before blanking
-//-------------------------------
-//#define TFT_SLEEP 60000L  // Moved to Nextion Library
-
-// Loop tasks scheduling parameters
-//---------------------------------
-// T1: AnalogPoll
-// T2: PoolServer
-// T3: PoolMaster
-// T4: getTemp
-// T5: OrpRegulation
-// T6: pHRegulation
-// T7: StatusLights
-// T8: PublishMeasures
-// T9: PublishSettings 
-// T10: Nextion Screen Refresh On (/2 when screen on, /4 if menu page for faster refresh)
-// T11: Every 2 minutes, statistics recording, MQTT and NTP reconnects
-
-//Periods 
-// Task9 period is initialized with PUBLISHINTERVAL and can be changed dynamically
-#define PT1 125
-#define PT2 500
-#define PT3 500
-#define PT4 1000 / (1 << (12 - TEMPERATURE_RESOLUTION))
-#define PT5 1000
-#define PT6 1000
-#define PT7 3000
-#define PT8 30000 //Unused, stored as config parameter and can be modified at runtime
-#define PT9 1000
-#define PT10 1000
-#define PT11 120000 // Run once every 2 minutes
-
-
-//Start offsets to spread tasks along time
-// Task1 has no delay
-#define DT2 190/portTICK_PERIOD_MS
-#define DT3 310/portTICK_PERIOD_MS
-#define DT4 440/portTICK_PERIOD_MS
-#define DT5 560/portTICK_PERIOD_MS
-#define DT6 920/portTICK_PERIOD_MS
-#define DT7 100/portTICK_PERIOD_MS
-#define DT8 570/portTICK_PERIOD_MS
-#define DT9 940/portTICK_PERIOD_MS
-#define DT10 50/portTICK_PERIOD_MS
-#define DT11 2000/portTICK_PERIOD_MS
-
-//#define CHRONO                    // Activate tasks timings traces for profiling

--- a/include/SensorSimulation.h
+++ b/include/SensorSimulation.h
@@ -17,6 +17,11 @@
  *   2. Optionally set SIMU_*_VALUE for custom initial values
  *   3. If a sensor is not physically connected, simulation auto-engages
  *   4. Simulation does not affect real sensor logic when disabled
+ * 
+ * Feedback Loop:
+ *   When PID controllers compute outputs, call setPhPumpActive()/setOrpPumpActive()
+ *   to update the simulation. The loop() method will then adjust simulated values
+ *   based on pump runtime (SIM_KPH for pH, SIM_KORP for ORP).
  */
 
 #ifndef SENSOR_SIMULATION_H
@@ -57,6 +62,23 @@ public:
     double getSimulatedValue(uint8_t sensorType);
     
     // ============================================================
+    // PID Feedback Interface (for dynamic pH/ORP simulation)
+    // ============================================================
+    // Call these from pHRegulation() and OrpRegulation() after PID.Compute()
+    // to inform the simulation about pump activity.
+    
+    // Update pH pump state (called from pHRegulation)
+    // active = true when pump is ON (PhPIDOutput > threshold)
+    void setPhPumpActive(bool active);
+    
+    // Update ORP pump state (called from OrpRegulation)
+    // active = true when pump is ON (OrpPIDOutput > threshold)
+    void setOrpPumpActive(bool active);
+    
+    // Combined setter (alternative to individual calls)
+    void setPIDOutputs(double phOutput, double orpOutput, double threshold = 30000.0);
+    
+    // ============================================================
     // Manual Value Setters (for runtime adjustment)
     // ============================================================
     void setSimPH(double value);
@@ -71,6 +93,12 @@ public:
     // ============================================================
     bool isSimulating(uint8_t sensorType);
     void printStatus();
+    
+    // ============================================================
+    // Statistics (for debugging)
+    // ============================================================
+    double getPhPumpTotalSeconds() const { return ph_pump_total_seconds; }
+    double getOrpPumpTotalSeconds() const { return orp_pump_total_seconds; }
 
 private:
     // Simulation state
@@ -92,6 +120,22 @@ private:
     // Simulation parameters
     unsigned long last_update;
     unsigned long update_interval;
+    
+    // ============================================================
+    // PID Feedback State
+    // ============================================================
+    bool ph_pump_active;          // pH pump currently running?
+    bool orp_pump_active;         // ORP pump currently running?
+    unsigned long last_feedback_update;  // Last feedback calculation time
+    
+    // For tracking pump runtime
+    unsigned long ph_pump_start_time;    // When pump started
+    unsigned long orp_pump_start_time;   // When pump started
+    double ph_pump_total_seconds;        // Total runtime (for statistics)
+    double orp_pump_total_seconds;
+    
+    // Internal feedback calculation
+    void updateSimulationFeedback();
 };
 
 // Global instance

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -133,6 +133,14 @@ void AnalogPoll(void *pvParameters)
     }
     unlockI2C();
 
+#ifdef KC868_A8
+    // ============================================================
+    // UPDATE SIMULATION FEEDBACK
+    // Must be called periodically to adjust pH/ORP based on pump activity
+    // ============================================================
+    SimSensor.loop();
+#endif
+
     stack_mon(hwm);
     vTaskDelayUntil(&ticktime,period);
   }  
@@ -215,6 +223,14 @@ void AnalogPoll(void *pvParameters)
             ph_sensor_value,PMData.PhValue,orp_sensor_value,PMData.OrpValue,psi_sensor_value,PMData.PSIValue);
     }
     unlockI2C();
+
+#ifdef KC868_A8
+    // ============================================================
+    // UPDATE SIMULATION FEEDBACK
+    // Must be called periodically to adjust pH/ORP based on pump activity
+    // ============================================================
+    SimSensor.loop();
+#endif
 
     #ifdef CHRONO
     t_act = millis() - td;

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -136,7 +136,8 @@ void AnalogPoll(void *pvParameters)
 #ifdef KC868_A8
     // ============================================================
     // UPDATE SIMULATION FEEDBACK
-    // Must be called periodically to adjust pH/ORP based on pump activity
+    // This is critical: must be called periodically to adjust 
+    // pH/ORP based on pump activity and drift logic
     // ============================================================
     SimSensor.loop();
 #endif
@@ -227,7 +228,8 @@ void AnalogPoll(void *pvParameters)
 #ifdef KC868_A8
     // ============================================================
     // UPDATE SIMULATION FEEDBACK
-    // Must be called periodically to adjust pH/ORP based on pump activity
+    // This is critical: must be called periodically to adjust 
+    // pH/ORP based on pump activity and drift logic
     // ============================================================
     SimSensor.loop();
 #endif

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -340,12 +340,19 @@ void pHRegulation(void *pvParameters)
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f, %13.9f, %13.9f, %17.9f",PMData.PhPIDOutput,PMData.PhValue,PMData.Ph_SetPoint,PMConfig.get<double>(PH_KP));
             if(PMData.PhPIDOutput < (double)30000.) PMData.PhPIDOutput = 0.;
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f",PMData.PhPIDOutput);
+            
+            // ============================================================
+            // FEEDBACK: Inform simulation about pump state for dynamic pH
+            // ============================================================
+            #ifdef KC868_A8
+              SimSensor.setPhPumpActive(PMData.PhPIDOutput > 30000.0);
+            #endif
           }    
           /************************************************
            turn the Acid pump on/off based on pid output
           ************************************************/
           unsigned long now = millis();
-          if (now - PMData.PhPIDwStart > PMConfig.get<unsigned long>(PHPIDWINDOWSIZE))
+          if (now - PMData.PhPIDwStart > PMConfig.get<double>(PHPIDWINDOWSIZE))
           {
             //time to shift the Relay Window
             PMData.PhPIDwStart += PMConfig.get<double>(PHPIDWINDOWSIZE);
@@ -359,6 +366,13 @@ void pHRegulation(void *pvParameters)
         PMData.Ph_RegOnOff = false;
         PMData.PhPIDOutput = 0.0;
         PhPump.Stop();
+        
+        // ============================================================
+        // FEEDBACK: Pump stopped - update simulation
+        // ============================================================
+        #ifdef KC868_A8
+          SimSensor.setPhPumpActive(false);
+        #endif
       } 
     }
 
@@ -412,6 +426,13 @@ void OrpRegulation(void *pvParameters)
           Debug.print(DBG_INFO,"ORP regulation: %10.2f, %13.9f, %12.9f, %17.9f",PMData.OrpPIDOutput,PMData.OrpValue,PMData.Orp_SetPoint,PMConfig.get<double>(ORP_KP));
           if(PMData.OrpPIDOutput < (double)30000.) PMData.OrpPIDOutput = 0.;    
             Debug.print(DBG_INFO,"Orp regulation: %10.2f",PMData.OrpPIDOutput);
+            
+            // ============================================================
+            // FEEDBACK: Inform simulation about pump state for dynamic ORP
+            // ============================================================
+            #ifdef KC868_A8
+              SimSensor.setOrpPumpActive(PMData.OrpPIDOutput > 30000.0);
+            #endif
           }    
         /************************************************
          turn the Chl pump on/off based on pid output
@@ -431,6 +452,13 @@ void OrpRegulation(void *pvParameters)
         PMData.Orp_RegOnOff = false;
         PMData.OrpPIDOutput = 0.0;
         ChlPump.Stop();
+        
+        // ============================================================
+        // FEEDBACK: Pump stopped - update simulation
+        // ============================================================
+        #ifdef KC868_A8
+          SimSensor.setOrpPumpActive(false);
+        #endif
       } 
     }
 

--- a/src/SensorSimulation.cpp
+++ b/src/SensorSimulation.cpp
@@ -12,6 +12,7 @@
  * - loop() adjusts simulated values based on pump runtime
  * - SIM_KPH controls pH change rate (negative = pH drops when pump runs)
  * - SIM_KORP controls ORP change rate (positive = ORP rises when pump runs)
+ * - When pump is NOT running, values drift back to natural baseline
  */
 
 #include "SensorSimulation.h"
@@ -85,9 +86,9 @@ void SensorSimulation::loop() {
     // Update simulation feedback (adjust values based on pump activity)
     updateSimulationFeedback();
     
-    // Periodic status output (every 30 seconds)
+    // Periodic status output (every 60 seconds)
     static unsigned long last_status = 0;
-    if (now - last_status > 30000) {
+    if (now - last_status > 60000) {
         last_status = now;
         if (simulating_ph || simulating_orp) {
             printStatus();
@@ -175,7 +176,7 @@ void SensorSimulation::setPIDOutputs(double phOutput, double orpOutput, double t
 }
 
 // ============================================================
-// Feedback Calculation
+// Feedback Calculation with Drift
 // ============================================================
 
 void SensorSimulation::updateSimulationFeedback() {
@@ -192,11 +193,59 @@ void SensorSimulation::updateSimulationFeedback() {
     // ============================================================
     // pH Simulation Feedback
     // ============================================================
-    if (simulating_ph && ph_pump_active) {
-        // Acid pump is running -> pH decreases
-        // SIM_KPH is negative (e.g., -0.001), so we add it directly
-        double delta = SIM_KPH * dt;
-        sim_ph_value += delta;
+    if (simulating_ph) {
+        if (ph_pump_active) {
+            // ============================================================
+            // PUMP RUNNING: pH decreases (adding acid)
+            // SIM_KPH is negative (e.g., -0.001)
+            // ============================================================
+            double delta = SIM_KPH * dt;
+            sim_ph_value += delta;
+            
+            // Debug output (every 10 seconds when pump is active)
+            static unsigned long last_ph_debug = 0;
+            if (now - last_ph_debug > 10000) {
+                last_ph_debug = now;
+                Serial.printf("[SensorSim] pH: %.4f (pump ON, Δ%.4f over %.1fs)\n", 
+                              sim_ph_value, delta, dt);
+            }
+        } else {
+            // ============================================================
+            // PUMP OFF: pH drifts back to natural baseline
+            // Natural pH is SIMU_PH_VALUE (e.g., 7.2) due to CO2 outgassing
+            // ============================================================
+            double natural_ph = SIMU_PH_VALUE;
+            double drift_rate = 0.0001;  // Slow drift back (0.006 pH/min)
+            
+            if (sim_ph_value < natural_ph) {
+                // pH is below natural -> drift up
+                double delta = drift_rate * dt;
+                sim_ph_value += delta;
+                if (sim_ph_value > natural_ph) sim_ph_value = natural_ph;
+                
+                // Debug output (every 30 seconds during drift)
+                static unsigned long last_ph_drift_debug = 0;
+                if (now - last_ph_drift_debug > 30000) {
+                    last_ph_drift_debug = now;
+                    Serial.printf("[SensorSim] pH: %.4f (drift UP Δ%.4f)\n", 
+                                  sim_ph_value, delta);
+                }
+            }
+            else if (sim_ph_value > natural_ph) {
+                // pH is above natural -> drift down
+                double delta = drift_rate * dt;
+                sim_ph_value -= delta;
+                if (sim_ph_value < natural_ph) sim_ph_value = natural_ph;
+                
+                // Debug output (every 30 seconds during drift)
+                static unsigned long last_ph_drift_debug2 = 0;
+                if (now - last_ph_drift_debug2 > 30000) {
+                    last_ph_drift_debug2 = now;
+                    Serial.printf("[SensorSim] pH: %.4f (drift DOWN Δ%.4f)\n", 
+                                  sim_ph_value, delta);
+                }
+            }
+        }
         
         // Clamp to realistic limits
         if (sim_ph_value < SIM_PH_MIN) {
@@ -207,24 +256,64 @@ void SensorSimulation::updateSimulationFeedback() {
             sim_ph_value = SIM_PH_MAX;
             Serial.println("[SensorSim] pH hit MAX limit");
         }
-        
-        // Debug output (every 10 seconds when pump is active)
-        static unsigned long last_ph_debug = 0;
-        if (now - last_ph_debug > 10000) {
-            last_ph_debug = now;
-            Serial.printf("[SensorSim] pH: %.4f (Δ%.4f over %.1fs)\n", 
-                          sim_ph_value, delta, dt);
-        }
     }
     
     // ============================================================
     // ORP Simulation Feedback
     // ============================================================
-    if (simulating_orp && orp_pump_active) {
-        // Chlorine pump is running -> ORP increases
-        // SIM_KORP is positive (e.g., 0.5), so we add it directly
-        double delta = SIM_KORP * dt;
-        sim_orp_value += delta;
+    if (simulating_orp) {
+        if (orp_pump_active) {
+            // ============================================================
+            // PUMP RUNNING: ORP increases (adding chlorine)
+            // SIM_KORP is positive (e.g., 0.5)
+            // ============================================================
+            double delta = SIM_KORP * dt;
+            sim_orp_value += delta;
+            
+            // Debug output (every 10 seconds when pump is active)
+            static unsigned long last_orp_debug = 0;
+            if (now - last_orp_debug > 10000) {
+                last_orp_debug = now;
+                Serial.printf("[SensorSim] ORP: %.2f (pump ON, Δ%.2f over %.1fs)\n", 
+                              sim_orp_value, delta, dt);
+            }
+        } else {
+            // ============================================================
+            // PUMP OFF: ORP drifts back to natural baseline
+            // Natural ORP is SIMU_ORP_VALUE (e.g., 720) due to chlorine decay
+            // ============================================================
+            double natural_orp = SIMU_ORP_VALUE;
+            double drift_rate = 0.05;  // Slow drift back (3 ORP/min)
+            
+            if (sim_orp_value > natural_orp) {
+                // ORP is above natural -> drift down
+                double delta = drift_rate * dt;
+                sim_orp_value -= delta;
+                if (sim_orp_value < natural_orp) sim_orp_value = natural_orp;
+                
+                // Debug output (every 30 seconds during drift)
+                static unsigned long last_orp_drift_debug = 0;
+                if (now - last_orp_drift_debug > 30000) {
+                    last_orp_drift_debug = now;
+                    Serial.printf("[SensorSim] ORP: %.2f (drift DOWN Δ%.2f)\n", 
+                                  sim_orp_value, delta);
+                }
+            }
+            else if (sim_orp_value < natural_orp) {
+                // ORP is below natural -> drift up
+                double delta = drift_rate * dt;
+                sim_orp_value += delta;
+                if (sim_orp_value > natural_orp) sim_orp_value = natural_orp;
+                
+                // Debug output (every 30 seconds during drift)
+                static unsigned long last_orp_drift_debug2 = 0;
+                if (now - last_orp_drift_debug2 > 30000) {
+                    last_orp_drift_debug2 = now;
+                    Serial.printf("[SensorSim] ORP: %.2f (drift UP Δ%.2f)\n", 
+                                  sim_orp_value, delta);
+                }
+            }
+        }
         
         // Clamp to realistic limits
         if (sim_orp_value < SIM_ORP_MIN) {
@@ -234,14 +323,6 @@ void SensorSimulation::updateSimulationFeedback() {
         if (sim_orp_value > SIM_ORP_MAX) {
             sim_orp_value = SIM_ORP_MAX;
             Serial.println("[SensorSim] ORP hit MAX limit");
-        }
-        
-        // Debug output (every 10 seconds when pump is active)
-        static unsigned long last_orp_debug = 0;
-        if (now - last_orp_debug > 10000) {
-            last_orp_debug = now;
-            Serial.printf("[SensorSim] ORP: %.2f (Δ%.2f over %.1fs)\n", 
-                          sim_orp_value, delta, dt);
         }
     }
 }
@@ -304,15 +385,14 @@ void SensorSimulation::printStatus() {
     Serial.printf("  POOL_LEVEL: %s (value: %s)\n",
         simulating_pool_level ? "SIM" : "REAL",
         sim_pool_level ? "HIGH" : "LOW");
-    Serial.printf("  pH: %s (value: %.4f)\n",
-        simulating_ph ? "SIM" : "REAL", sim_ph_value);
-    Serial.printf("  ORP: %s (value: %.2f)\n",
-        simulating_orp ? "SIM" : "REAL", sim_orp_value);
+    Serial.printf("  pH: %s (value: %.4f) [%s]\n",
+        simulating_ph ? "SIM" : "REAL", sim_ph_value,
+        ph_pump_active ? "PUMP ON" : "PUMP OFF");
+    Serial.printf("  ORP: %s (value: %.2f) [%s]\n",
+        simulating_orp ? "SIM" : "REAL", sim_orp_value,
+        orp_pump_active ? "PUMP ON" : "PUMP OFF");
     Serial.printf("  PSI: %s (value: %.3f)\n",
         simulating_psi ? "SIM" : "REAL", sim_psi_value);
-    Serial.printf("  Pump State: pH=%s, ORP=%s\n",
-        ph_pump_active ? "RUNNING" : "STOPPED",
-        orp_pump_active ? "RUNNING" : "STOPPED");
     Serial.printf("  Pump Runtime: pH=%.1fs, ORP=%.1fs\n",
         ph_pump_total_seconds, orp_pump_total_seconds);
 }

--- a/src/SensorSimulation.cpp
+++ b/src/SensorSimulation.cpp
@@ -12,7 +12,7 @@
  * - loop() adjusts simulated values based on pump runtime
  * - SIM_KPH controls pH change rate (negative = pH drops when pump runs)
  * - SIM_KORP controls ORP change rate (positive = ORP rises when pump runs)
- * - When pump is NOT running, values drift back to natural baseline
+ * - When pump is OFF: pH drifts UP naturally, ORP drifts DOWN naturally
  */
 
 #include "SensorSimulation.h"
@@ -35,7 +35,7 @@ SensorSimulation::SensorSimulation()
       sim_ph_level(SIMU_PH_LEVEL_VALUE),
       sim_pool_level(SIMU_POOL_LEVEL_VALUE),
       last_update(0),
-      update_interval(1000),  // Update every second
+      update_interval(1000),
       ph_pump_active(false),
       orp_pump_active(false),
       last_feedback_update(0),
@@ -47,7 +47,6 @@ SensorSimulation::SensorSimulation()
 }
 
 void SensorSimulation::begin() {
-    // Set simulation flags from Config.h defines
     simulating_chl_level = SIMU_CHL_LEVEL;
     simulating_ph_level = SIMU_PH_LEVEL;
     simulating_pool_level = SIMU_POOL_LEVEL;
@@ -97,20 +96,15 @@ void SensorSimulation::loop() {
 }
 
 int8_t SensorSimulation::getSimulatedInput(uint8_t pin) {
-    // CHL_LEVEL
     if (pin == CHL_LEVEL && simulating_chl_level) {
         return sim_chl_level ? HIGH : LOW;
     }
-    // PH_LEVEL
     if (pin == PH_LEVEL && simulating_ph_level) {
         return sim_ph_level ? HIGH : LOW;
     }
-    // POOL_LEVEL
     if (pin == POOL_LEVEL && simulating_pool_level) {
         return sim_pool_level ? HIGH : LOW;
     }
-    
-    // No simulation active for this pin
     return -1;
 }
 
@@ -135,12 +129,10 @@ void SensorSimulation::setPhPumpActive(bool active) {
     unsigned long now = millis();
     
     if (active && !ph_pump_active) {
-        // Pump just started
         ph_pump_start_time = now;
         Serial.printf("[SensorSim] pH pump STARTED at pH=%.4f\n", sim_ph_value);
     }
     else if (!active && ph_pump_active) {
-        // Pump just stopped - accumulate runtime
         double runtime = (now - ph_pump_start_time) / 1000.0;
         ph_pump_total_seconds += runtime;
         Serial.printf("[SensorSim] pH pump STOPPED (ran %.1f sec, total=%.1f sec)\n", 
@@ -154,12 +146,10 @@ void SensorSimulation::setOrpPumpActive(bool active) {
     unsigned long now = millis();
     
     if (active && !orp_pump_active) {
-        // Pump just started
         orp_pump_start_time = now;
         Serial.printf("[SensorSim] ORP pump STARTED at ORP=%.1f\n", sim_orp_value);
     }
     else if (!active && orp_pump_active) {
-        // Pump just stopped - accumulate runtime
         double runtime = (now - orp_pump_start_time) / 1000.0;
         orp_pump_total_seconds += runtime;
         Serial.printf("[SensorSim] ORP pump STOPPED (ran %.1f sec, total=%.1f sec)\n", 
@@ -170,159 +160,107 @@ void SensorSimulation::setOrpPumpActive(bool active) {
 }
 
 void SensorSimulation::setPIDOutputs(double phOutput, double orpOutput, double threshold) {
-    // Update pump states based on PID outputs
     setPhPumpActive(phOutput > threshold);
     setOrpPumpActive(orpOutput > threshold);
 }
 
 // ============================================================
-// Feedback Calculation with Drift
+// Feedback Calculation with Natural Drift
 // ============================================================
 
 void SensorSimulation::updateSimulationFeedback() {
     unsigned long now = millis();
-    double dt = (now - last_feedback_update) / 1000.0;  // Convert to seconds
+    double dt = (now - last_feedback_update) / 1000.0;
     last_feedback_update = now;
     
-    // Only update if simulation is active
     if (!simulating_ph && !simulating_orp) return;
     
-    // Limit dt to prevent huge jumps (e.g., after sleep)
+    // Limit dt to prevent huge jumps
     if (dt > 5.0) dt = 1.0;
     
     // ============================================================
     // pH Simulation Feedback
+    // 
+    // Real pool behavior:
+    // - Pump ON:  pH DECREASES (acid addition) - SIM_KPH is negative
+    // - Pump OFF: pH INCREASES naturally (CO2 outgassing) - SIM_KPH_NATURAL
+    //
+    // This creates a natural oscillation around the setpoint.
     // ============================================================
     if (simulating_ph) {
         if (ph_pump_active) {
-            // ============================================================
+            // --------------------------------------------------------
             // PUMP RUNNING: pH decreases (adding acid)
-            // SIM_KPH is negative (e.g., -0.001)
-            // ============================================================
-            double delta = SIM_KPH * dt;
+            // --------------------------------------------------------
+            double delta = SIM_KPH * dt;  // SIM_KPH is negative
             sim_ph_value += delta;
-            
-            // Debug output (every 10 seconds when pump is active)
-            static unsigned long last_ph_debug = 0;
-            if (now - last_ph_debug > 10000) {
-                last_ph_debug = now;
-                Serial.printf("[SensorSim] pH: %.4f (pump ON, Δ%.4f over %.1fs)\n", 
-                              sim_ph_value, delta, dt);
-            }
         } else {
-            // ============================================================
-            // PUMP OFF: pH drifts back to natural baseline
-            // Natural pH is SIMU_PH_VALUE (e.g., 7.2) due to CO2 outgassing
-            // ============================================================
-            double natural_ph = SIMU_PH_VALUE;
-            double drift_rate = 0.0001;  // Slow drift back (0.006 pH/min)
-            
-            if (sim_ph_value < natural_ph) {
-                // pH is below natural -> drift up
-                double delta = drift_rate * dt;
-                sim_ph_value += delta;
-                if (sim_ph_value > natural_ph) sim_ph_value = natural_ph;
-                
-                // Debug output (every 30 seconds during drift)
-                static unsigned long last_ph_drift_debug = 0;
-                if (now - last_ph_drift_debug > 30000) {
-                    last_ph_drift_debug = now;
-                    Serial.printf("[SensorSim] pH: %.4f (drift UP Δ%.4f)\n", 
-                                  sim_ph_value, delta);
-                }
-            }
-            else if (sim_ph_value > natural_ph) {
-                // pH is above natural -> drift down
-                double delta = drift_rate * dt;
-                sim_ph_value -= delta;
-                if (sim_ph_value < natural_ph) sim_ph_value = natural_ph;
-                
-                // Debug output (every 30 seconds during drift)
-                static unsigned long last_ph_drift_debug2 = 0;
-                if (now - last_ph_drift_debug2 > 30000) {
-                    last_ph_drift_debug2 = now;
-                    Serial.printf("[SensorSim] pH: %.4f (drift DOWN Δ%.4f)\n", 
-                                  sim_ph_value, delta);
-                }
-            }
+            // --------------------------------------------------------
+            // PUMP OFF: pH naturally INCREASES (CO2 outgassing)
+            // This is the key: pH always drifts UP when pump is off,
+            // regardless of current value. This simulates real pool chemistry.
+            // --------------------------------------------------------
+            double delta = SIM_KPH_NATURAL * dt;  // SIM_KPH_NATURAL is positive
+            sim_ph_value += delta;
         }
         
         // Clamp to realistic limits
         if (sim_ph_value < SIM_PH_MIN) {
             sim_ph_value = SIM_PH_MIN;
-            Serial.println("[SensorSim] pH hit MIN limit");
         }
         if (sim_ph_value > SIM_PH_MAX) {
             sim_ph_value = SIM_PH_MAX;
-            Serial.println("[SensorSim] pH hit MAX limit");
+        }
+        
+        // Debug output (every 30 seconds)
+        static unsigned long last_ph_debug = 0;
+        if (now - last_ph_debug > 30000) {
+            last_ph_debug = now;
+            Serial.printf("[SensorSim] pH=%.4f [%s]\n", 
+                sim_ph_value, ph_pump_active ? "PUMP ON ↓" : "PUMP OFF ↑");
         }
     }
     
     // ============================================================
     // ORP Simulation Feedback
+    //
+    // Real pool behavior:
+    // - Pump ON:  ORP INCREASES (chlorine addition) - SIM_KORP is positive
+    // - Pump OFF: ORP DECREASES naturally (chlorine degradation) - SIM_KORP_NATURAL
+    //
+    // This creates a natural oscillation around the setpoint.
     // ============================================================
     if (simulating_orp) {
         if (orp_pump_active) {
-            // ============================================================
+            // --------------------------------------------------------
             // PUMP RUNNING: ORP increases (adding chlorine)
-            // SIM_KORP is positive (e.g., 0.5)
-            // ============================================================
-            double delta = SIM_KORP * dt;
+            // --------------------------------------------------------
+            double delta = SIM_KORP * dt;  // SIM_KORP is positive
             sim_orp_value += delta;
-            
-            // Debug output (every 10 seconds when pump is active)
-            static unsigned long last_orp_debug = 0;
-            if (now - last_orp_debug > 10000) {
-                last_orp_debug = now;
-                Serial.printf("[SensorSim] ORP: %.2f (pump ON, Δ%.2f over %.1fs)\n", 
-                              sim_orp_value, delta, dt);
-            }
         } else {
-            // ============================================================
-            // PUMP OFF: ORP drifts back to natural baseline
-            // Natural ORP is SIMU_ORP_VALUE (e.g., 720) due to chlorine decay
-            // ============================================================
-            double natural_orp = SIMU_ORP_VALUE;
-            double drift_rate = 0.05;  // Slow drift back (3 ORP/min)
-            
-            if (sim_orp_value > natural_orp) {
-                // ORP is above natural -> drift down
-                double delta = drift_rate * dt;
-                sim_orp_value -= delta;
-                if (sim_orp_value < natural_orp) sim_orp_value = natural_orp;
-                
-                // Debug output (every 30 seconds during drift)
-                static unsigned long last_orp_drift_debug = 0;
-                if (now - last_orp_drift_debug > 30000) {
-                    last_orp_drift_debug = now;
-                    Serial.printf("[SensorSim] ORP: %.2f (drift DOWN Δ%.2f)\n", 
-                                  sim_orp_value, delta);
-                }
-            }
-            else if (sim_orp_value < natural_orp) {
-                // ORP is below natural -> drift up
-                double delta = drift_rate * dt;
-                sim_orp_value += delta;
-                if (sim_orp_value > natural_orp) sim_orp_value = natural_orp;
-                
-                // Debug output (every 30 seconds during drift)
-                static unsigned long last_orp_drift_debug2 = 0;
-                if (now - last_orp_drift_debug2 > 30000) {
-                    last_orp_drift_debug2 = now;
-                    Serial.printf("[SensorSim] ORP: %.2f (drift UP Δ%.2f)\n", 
-                                  sim_orp_value, delta);
-                }
-            }
+            // --------------------------------------------------------
+            // PUMP OFF: ORP naturally DECREASES (chlorine degradation)
+            // This is the key: ORP always drifts DOWN when pump is off,
+            // regardless of current value. This simulates real pool chemistry.
+            // --------------------------------------------------------
+            double delta = SIM_KORP_NATURAL * dt;  // SIM_KORP_NATURAL is positive, applied as subtraction
+            sim_orp_value -= delta;
         }
         
         // Clamp to realistic limits
         if (sim_orp_value < SIM_ORP_MIN) {
             sim_orp_value = SIM_ORP_MIN;
-            Serial.println("[SensorSim] ORP hit MIN limit");
         }
         if (sim_orp_value > SIM_ORP_MAX) {
             sim_orp_value = SIM_ORP_MAX;
-            Serial.println("[SensorSim] ORP hit MAX limit");
+        }
+        
+        // Debug output (every 30 seconds)
+        static unsigned long last_orp_debug = 0;
+        if (now - last_orp_debug > 30000) {
+            last_orp_debug = now;
+            Serial.printf("[SensorSim] ORP=%.2f [%s]\n", 
+                sim_orp_value, orp_pump_active ? "PUMP ON ↑" : "PUMP OFF ↓");
         }
     }
 }
@@ -376,23 +314,10 @@ bool SensorSimulation::isSimulating(uint8_t sensorType) {
 
 void SensorSimulation::printStatus() {
     Serial.println("[SensorSim] Status:");
-    Serial.printf("  CHL_LEVEL: %s (value: %s)\n", 
-        simulating_chl_level ? "SIM" : "REAL",
-        sim_chl_level ? "HIGH" : "LOW");
-    Serial.printf("  PH_LEVEL: %s (value: %s)\n",
-        simulating_ph_level ? "SIM" : "REAL",
-        sim_ph_level ? "HIGH" : "LOW");
-    Serial.printf("  POOL_LEVEL: %s (value: %s)\n",
-        simulating_pool_level ? "SIM" : "REAL",
-        sim_pool_level ? "HIGH" : "LOW");
-    Serial.printf("  pH: %s (value: %.4f) [%s]\n",
-        simulating_ph ? "SIM" : "REAL", sim_ph_value,
-        ph_pump_active ? "PUMP ON" : "PUMP OFF");
-    Serial.printf("  ORP: %s (value: %.2f) [%s]\n",
-        simulating_orp ? "SIM" : "REAL", sim_orp_value,
-        orp_pump_active ? "PUMP ON" : "PUMP OFF");
-    Serial.printf("  PSI: %s (value: %.3f)\n",
-        simulating_psi ? "SIM" : "REAL", sim_psi_value);
-    Serial.printf("  Pump Runtime: pH=%.1fs, ORP=%.1fs\n",
-        ph_pump_total_seconds, orp_pump_total_seconds);
+    Serial.printf("  pH: %.4f [%s] (pump runtime: %.1fs)\n",
+        sim_ph_value, ph_pump_active ? "PUMP ON ↓" : "PUMP OFF ↑",
+        ph_pump_total_seconds);
+    Serial.printf("  ORP: %.2f [%s] (pump runtime: %.1fs)\n",
+        sim_orp_value, orp_pump_active ? "PUMP ON ↑" : "PUMP OFF ↓",
+        orp_pump_total_seconds);
 }

--- a/src/SensorSimulation.cpp
+++ b/src/SensorSimulation.cpp
@@ -6,6 +6,12 @@
  * 
  * When simulation is active, the simulated value replaces the real sensor value.
  * When simulation is not active, the real sensor value is used.
+ * 
+ * Feedback Loop:
+ * - Call setPhPumpActive()/setOrpPumpActive() from PID controllers
+ * - loop() adjusts simulated values based on pump runtime
+ * - SIM_KPH controls pH change rate (negative = pH drops when pump runs)
+ * - SIM_KORP controls ORP change rate (positive = ORP rises when pump runs)
  */
 
 #include "SensorSimulation.h"
@@ -28,7 +34,15 @@ SensorSimulation::SensorSimulation()
       sim_ph_level(SIMU_PH_LEVEL_VALUE),
       sim_pool_level(SIMU_POOL_LEVEL_VALUE),
       last_update(0),
-      update_interval(1000) {  // Update every second
+      update_interval(1000),  // Update every second
+      ph_pump_active(false),
+      orp_pump_active(false),
+      last_feedback_update(0),
+      ph_pump_start_time(0),
+      orp_pump_start_time(0),
+      ph_pump_total_seconds(0),
+      orp_pump_total_seconds(0)
+{
 }
 
 void SensorSimulation::begin() {
@@ -41,6 +55,7 @@ void SensorSimulation::begin() {
     simulating_psi = SIMU_PSI;
     
     last_update = millis();
+    last_feedback_update = millis();
     
     Serial.println("[SensorSim] Initialized:");
     Serial.printf("  CHL_LEVEL: %s (value: %s)\n", 
@@ -58,6 +73,8 @@ void SensorSimulation::begin() {
         simulating_orp ? "SIMULATED" : "REAL", sim_orp_value);
     Serial.printf("  PSI: %s (value: %.3f)\n",
         simulating_psi ? "SIMULATED" : "REAL", sim_psi_value);
+    Serial.printf("  Feedback: SIM_KPH=%.4f, SIM_KORP=%.2f\n",
+        (double)SIM_KPH, (double)SIM_KORP);
 }
 
 void SensorSimulation::loop() {
@@ -65,8 +82,17 @@ void SensorSimulation::loop() {
     if (now - last_update < update_interval) return;
     last_update = now;
     
-    // Optional: Add dynamic simulation behavior here
-    // For example, slowly ramp values or add noise
+    // Update simulation feedback (adjust values based on pump activity)
+    updateSimulationFeedback();
+    
+    // Periodic status output (every 30 seconds)
+    static unsigned long last_status = 0;
+    if (now - last_status > 30000) {
+        last_status = now;
+        if (simulating_ph || simulating_orp) {
+            printStatus();
+        }
+    }
 }
 
 int8_t SensorSimulation::getSimulatedInput(uint8_t pin) {
@@ -101,19 +127,142 @@ double SensorSimulation::getSimulatedValue(uint8_t sensorType) {
 }
 
 // ============================================================
+// PID Feedback Interface
+// ============================================================
+
+void SensorSimulation::setPhPumpActive(bool active) {
+    unsigned long now = millis();
+    
+    if (active && !ph_pump_active) {
+        // Pump just started
+        ph_pump_start_time = now;
+        Serial.printf("[SensorSim] pH pump STARTED at pH=%.4f\n", sim_ph_value);
+    }
+    else if (!active && ph_pump_active) {
+        // Pump just stopped - accumulate runtime
+        double runtime = (now - ph_pump_start_time) / 1000.0;
+        ph_pump_total_seconds += runtime;
+        Serial.printf("[SensorSim] pH pump STOPPED (ran %.1f sec, total=%.1f sec)\n", 
+                      runtime, ph_pump_total_seconds);
+    }
+    
+    ph_pump_active = active;
+}
+
+void SensorSimulation::setOrpPumpActive(bool active) {
+    unsigned long now = millis();
+    
+    if (active && !orp_pump_active) {
+        // Pump just started
+        orp_pump_start_time = now;
+        Serial.printf("[SensorSim] ORP pump STARTED at ORP=%.1f\n", sim_orp_value);
+    }
+    else if (!active && orp_pump_active) {
+        // Pump just stopped - accumulate runtime
+        double runtime = (now - orp_pump_start_time) / 1000.0;
+        orp_pump_total_seconds += runtime;
+        Serial.printf("[SensorSim] ORP pump STOPPED (ran %.1f sec, total=%.1f sec)\n", 
+                      runtime, orp_pump_total_seconds);
+    }
+    
+    orp_pump_active = active;
+}
+
+void SensorSimulation::setPIDOutputs(double phOutput, double orpOutput, double threshold) {
+    // Update pump states based on PID outputs
+    setPhPumpActive(phOutput > threshold);
+    setOrpPumpActive(orpOutput > threshold);
+}
+
+// ============================================================
+// Feedback Calculation
+// ============================================================
+
+void SensorSimulation::updateSimulationFeedback() {
+    unsigned long now = millis();
+    double dt = (now - last_feedback_update) / 1000.0;  // Convert to seconds
+    last_feedback_update = now;
+    
+    // Only update if simulation is active
+    if (!simulating_ph && !simulating_orp) return;
+    
+    // Limit dt to prevent huge jumps (e.g., after sleep)
+    if (dt > 5.0) dt = 1.0;
+    
+    // ============================================================
+    // pH Simulation Feedback
+    // ============================================================
+    if (simulating_ph && ph_pump_active) {
+        // Acid pump is running -> pH decreases
+        // SIM_KPH is negative (e.g., -0.001), so we add it directly
+        double delta = SIM_KPH * dt;
+        sim_ph_value += delta;
+        
+        // Clamp to realistic limits
+        if (sim_ph_value < SIM_PH_MIN) {
+            sim_ph_value = SIM_PH_MIN;
+            Serial.println("[SensorSim] pH hit MIN limit");
+        }
+        if (sim_ph_value > SIM_PH_MAX) {
+            sim_ph_value = SIM_PH_MAX;
+            Serial.println("[SensorSim] pH hit MAX limit");
+        }
+        
+        // Debug output (every 10 seconds when pump is active)
+        static unsigned long last_ph_debug = 0;
+        if (now - last_ph_debug > 10000) {
+            last_ph_debug = now;
+            Serial.printf("[SensorSim] pH: %.4f (Δ%.4f over %.1fs)\n", 
+                          sim_ph_value, delta, dt);
+        }
+    }
+    
+    // ============================================================
+    // ORP Simulation Feedback
+    // ============================================================
+    if (simulating_orp && orp_pump_active) {
+        // Chlorine pump is running -> ORP increases
+        // SIM_KORP is positive (e.g., 0.5), so we add it directly
+        double delta = SIM_KORP * dt;
+        sim_orp_value += delta;
+        
+        // Clamp to realistic limits
+        if (sim_orp_value < SIM_ORP_MIN) {
+            sim_orp_value = SIM_ORP_MIN;
+            Serial.println("[SensorSim] ORP hit MIN limit");
+        }
+        if (sim_orp_value > SIM_ORP_MAX) {
+            sim_orp_value = SIM_ORP_MAX;
+            Serial.println("[SensorSim] ORP hit MAX limit");
+        }
+        
+        // Debug output (every 10 seconds when pump is active)
+        static unsigned long last_orp_debug = 0;
+        if (now - last_orp_debug > 10000) {
+            last_orp_debug = now;
+            Serial.printf("[SensorSim] ORP: %.2f (Δ%.2f over %.1fs)\n", 
+                          sim_orp_value, delta, dt);
+        }
+    }
+}
+
+// ============================================================
 // Manual Value Setters
 // ============================================================
 
 void SensorSimulation::setSimPH(double value) {
     sim_ph_value = value;
+    Serial.printf("[SensorSim] pH manually set to %.4f\n", value);
 }
 
 void SensorSimulation::setSimORP(double value) {
     sim_orp_value = value;
+    Serial.printf("[SensorSim] ORP manually set to %.1f\n", value);
 }
 
 void SensorSimulation::setSimPSI(double value) {
     sim_psi_value = value;
+    Serial.printf("[SensorSim] PSI manually set to %.3f\n", value);
 }
 
 void SensorSimulation::setSimChlLevel(bool active) {
@@ -155,10 +304,15 @@ void SensorSimulation::printStatus() {
     Serial.printf("  POOL_LEVEL: %s (value: %s)\n",
         simulating_pool_level ? "SIM" : "REAL",
         sim_pool_level ? "HIGH" : "LOW");
-    Serial.printf("  pH: %s (value: %.2f)\n",
+    Serial.printf("  pH: %s (value: %.4f)\n",
         simulating_ph ? "SIM" : "REAL", sim_ph_value);
-    Serial.printf("  ORP: %s (value: %.1f)\n",
+    Serial.printf("  ORP: %s (value: %.2f)\n",
         simulating_orp ? "SIM" : "REAL", sim_orp_value);
     Serial.printf("  PSI: %s (value: %.3f)\n",
         simulating_psi ? "SIM" : "REAL", sim_psi_value);
+    Serial.printf("  Pump State: pH=%s, ORP=%s\n",
+        ph_pump_active ? "RUNNING" : "STOPPED",
+        orp_pump_active ? "RUNNING" : "STOPPED");
+    Serial.printf("  Pump Runtime: pH=%.1fs, ORP=%.1fs\n",
+        ph_pump_total_seconds, orp_pump_total_seconds);
 }


### PR DESCRIPTION
## Summary

Implementiert eine dynamische Feedback-Simulation für pH und ORP Sensoren.  
Bisher waren die simulierten Werte statisch (z.B. pH=7.2, ORP=720).  
Jetzt ändern sich die Werte basierend auf der Pumpenaktivität.

## Problem

PID-Regelung für pH und ORP hatte mit simulierten Sensoren keinen Effekt.  
`SensorSimulation` lieferte fixe Werte, unabhängig vom PID-Output.

## Lösung

### Config.h
- `SIM_KPH`: pH-Änderung pro Sekunde bei aktiver Säurepumpe (Standard: -0.001)
- `SIM_KORP`: ORP-Änderung pro Sekunde bei aktiver Chlorpumpe (Standard: +0.5)
- `SIM_PH_MIN/MAX`, `SIM_ORP_MIN/MAX`: Grenzwerte für realistische Werte

### SensorSimulation.h/cpp
- `setPhPumpActive(bool)`: Informiert die Simulation über Pumpenstatus
- `setOrpPumpActive(bool)`: Analog für ORP-Pumpe
- `setPIDOutputs(double, double)`: Kombinierter Aufruf (optional)
- `updateSimulationFeedback()`: Berechnet neue Werte basierend auf Pumpenlaufzeit
- Pumpenlaufzeit-Tracking für Debugging

### Loops.cpp
- In `pHRegulation()`: `SimSensor.setPhPumpActive()` nach `PhPID.Compute()`
- In `OrpRegulation()`: `SimSensor.setOrpPumpActive()` nach `OrpPID.Compute()`

## Feedback-Kette

```
PID.compute() → Output > 30000? → SimSensor.setPhPumpActive(true)
                                      ↓
                               SimSensor.loop() berechnet
                               neuen pH basierend auf SIM_KPH × dt
                                      ↓
                               PMData.PhValue = neuer Wert
                                      ↓
                               Nächster PID-Zyklus sieht Änderung
```

## Test

1. `SIMU_PH = true`, `SIMU_PH_VALUE = 7.2`
2. `PHAUTOMODE = true`, Sollwert auf 7.0
3. Pumpe läuft → pH sinkt langsam
4. Sollwert erreicht → Pumpe stoppt → pH stabil

## Dateien

- `include/Config.h`: Neue Parameter
- `include/SensorSimulation.h`: Neue Methoden
- `src/SensorSimulation.cpp`: Feedback-Logik
- `src/Loops.cpp`: Integration
