### PR TITLE
fix(kc868a8): Reset all relays to OFF at boot

### DIFF
--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -340,6 +340,16 @@ void setup()
   PoolDeviceManager.InitDevicesInterlock();
   PoolDeviceManager.Begin();
 
+#ifdef KC868_A8
+  // After PoolDeviceManager.Begin(), PIN::Begin() may have set relays to
+  // an incorrect state due to active_level inversion on KC868-A8 hardware.
+  // Explicitly turn ALL 8 relays OFF to ensure a safe default state.
+  for (uint8_t i = 0; i < 8; i++) {
+    KC868.setRelay(i, false);
+  }
+  Debug.print(DBG_INFO,"[KC868-A8] All relays set to OFF (boot reset)");
+#endif
+
   // Initialize watch-dog
   esp_task_wdt_init(WDT_TIMEOUT, true);
 

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -373,6 +373,15 @@ void setup()
   Wire.write((uint8_t)0xFF);
   Wire.endTransmission();
 
+#ifdef KC868_A8
+  // Wire is now initialized — explicitly turn all relays OFF.
+  // KC868.begin() ran before Wire.begin() so its I2C write never reached hardware.
+  for (uint8_t i = 0; i < 8; i++) {
+    KC868.setRelay(i, true);
+  }
+  Debug.print(DBG_INFO,"[KC868-A8] All relays set to OFF (boot reset)");
+#endif
+
   // Initialize PIDs
   PMData.PhPIDwStart  = millis();
   PMData.OrpPIDwStart  = millis();

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -340,16 +340,6 @@ void setup()
   PoolDeviceManager.InitDevicesInterlock();
   PoolDeviceManager.Begin();
 
-#ifdef KC868_A8
-  // After PoolDeviceManager.Begin(), PIN::Begin() may have set relays to
-  // an incorrect state due to active_level inversion on KC868-A8 hardware.
-  // Explicitly turn ALL 8 relays OFF to ensure a safe default state.
-  for (uint8_t i = 0; i < 8; i++) {
-    KC868.setRelay(i, false);
-  }
-  Debug.print(DBG_INFO,"[KC868-A8] All relays set to OFF (boot reset)");
-#endif
-
   // Initialize watch-dog
   esp_task_wdt_init(WDT_TIMEOUT, true);
 
@@ -387,7 +377,7 @@ void setup()
   // Wire is now initialized — explicitly turn all relays OFF.
   // KC868.begin() ran before Wire.begin() so its I2C write never reached hardware.
   for (uint8_t i = 0; i < 8; i++) {
-    KC868.setRelay(i, false);
+    KC868.setRelay(i, true);
   }
   Debug.print(DBG_INFO,"[KC868-A8] All relays set to OFF (boot reset)");
 #endif

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -373,6 +373,15 @@ void setup()
   Wire.write((uint8_t)0xFF);
   Wire.endTransmission();
 
+#ifdef KC868_A8
+  // Wire is now initialized — explicitly turn all relays OFF.
+  // KC868.begin() ran before Wire.begin() so its I2C write never reached hardware.
+  for (uint8_t i = 0; i < 8; i++) {
+    KC868.setRelay(i, false);
+  }
+  Debug.print(DBG_INFO,"[KC868-A8] All relays set to OFF (boot reset)");
+#endif
+
   // Initialize PIDs
   PMData.PhPIDwStart  = millis();
   PMData.OrpPIDwStart  = millis();


### PR DESCRIPTION
## Problem

Nach einem Reboot bleiben die Relais in dem Zustand, den sie vor dem Reboot hatten. Beim Starten der Software wird kein definierter Grundzustand hergestellt.

## Ursache

`KC868.begin()` wird in Setup.cpp Zeile 283 aufgerufen, aber `Wire.begin()` (Zeile 373) wurde zu diesem Zeitpunkt noch nicht initialisiert. Der I2C-Schreibvorgang an den PCF8574 erreicht also die Hardware nicht — die Relais behalten ihren alten Zustand bei.

## Lösung

Explizites Zurücksetzen aller 8 PCF8574-Relais-Ausgänge auf OFF (LOW) **nach** `Wire.begin()` und `PoolDeviceManager.Begin()`:

```cpp
#ifdef KC868_A8
  for (uint8_t i = 0; i < 8; i++) {
    KC868.setRelay(i, false);
  }
  Debug.print(DBG_INFO,"[KC868-A8] All relays set to OFF (boot reset)");
#endif
```

## Effekt

Alle Relais (Filtration, pH-Pumpe, Chlor-Pumpe, Roboter, SWG, Füllpump, Projecktor, Spare) werden beim Boot garantiert auf AUS gesetzt, unabhängig vom vorherigen Zustand.