### PR TITLE
feat(simulation): Add dynamic analog sensor simulation with pump feedback

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -73,14 +73,14 @@
 // ============================================================
 
 // pH simulation
-#define SIM_PH_ACTIVE_RATE    0.02  // pH decrease per minute when acid pump is ON
-#define SIM_PH_DRIFT_RATE     0.005 // pH increase per minute when acid pump is OFF (natural)
+#define SIM_PH_ACTIVE_RATE    0.01  // pH decrease per minute when acid pump is ON
+#define SIM_PH_DRIFT_RATE     0.002 // pH increase per minute when acid pump is OFF (natural)
 #define SIM_PH_MIN            6.0   // Minimum simulated pH
 #define SIM_PH_MAX            8.5   // Maximum simulated pH
 
 // ORP simulation
-#define SIM_ORP_ACTIVE_RATE   5.0   // ORP increase per minute when chlorine pump is ON (mV)
-#define SIM_ORP_DRIFT_RATE    2.0   // ORP decrease per minute when chlorine pump is OFF (mV)
+#define SIM_ORP_ACTIVE_RATE   2.0   // ORP increase per minute when chlorine pump is ON (mV)
+#define SIM_ORP_DRIFT_RATE    1.0   // ORP decrease per minute when chlorine pump is OFF (mV)
 #define SIM_ORP_MIN           400.0 // Minimum simulated ORP (mV)
 #define SIM_ORP_MAX           900.0 // Maximum simulated ORP (mV)
 

--- a/include/Config.h
+++ b/include/Config.h
@@ -62,6 +62,28 @@
 #define SIMU_PH_LEVEL_VALUE   0     // Default: Low (tank not empty)
 #define SIMU_POOL_LEVEL_VALUE 1     // Default: HIGH (pool level OK)
 
+// ============================================================
+// ANALOG SIMULATION DYNAMICS (pH and ORP)
+// ============================================================
+// When a pump is active, the sensor value moves in the direction
+// the chemical causes. When the pump is off, the value drifts
+// naturally in the opposite direction.
+//
+// Update interval: Every 60 seconds (hardcoded in AnalogSimLoop)
+// ============================================================
+
+// pH simulation
+#define SIM_PH_ACTIVE_RATE    0.02  // pH decrease per minute when acid pump is ON
+#define SIM_PH_DRIFT_RATE     0.005 // pH increase per minute when acid pump is OFF (natural)
+#define SIM_PH_MIN            6.0   // Minimum simulated pH
+#define SIM_PH_MAX            8.5   // Maximum simulated pH
+
+// ORP simulation
+#define SIM_ORP_ACTIVE_RATE   5.0   // ORP increase per minute when chlorine pump is ON (mV)
+#define SIM_ORP_DRIFT_RATE    2.0   // ORP decrease per minute when chlorine pump is OFF (mV)
+#define SIM_ORP_MIN           400.0 // Minimum simulated ORP (mV)
+#define SIM_ORP_MAX           900.0 // Maximum simulated ORP (mV)
+
 // If you need to force network parameters (configuration with no screen)
 #define FORCE_NETWORK_PARAMS
 #ifdef FORCE_NETWORK_PARAMS

--- a/include/SensorSimulation.h
+++ b/include/SensorSimulation.h
@@ -67,6 +67,12 @@ public:
     void setSimPoolLevel(bool active);
     
     // ============================================================
+    // Analog Simulation Update (called every 60s by AnalogSimLoop)
+    // ============================================================
+    // Checks pump states and adjusts pH/ORP values accordingly.
+    void updateAnalogSimulation();
+    
+    // ============================================================
     // Status
     // ============================================================
     bool isSimulating(uint8_t sensorType);

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -201,10 +201,11 @@ void Pump::SetMinUpTime(unsigned long _minuptime)
 //This is typically called every day at midnight
 void Pump::ResetUpTime()
 {
-  StartTime = LastLoopMillis = 0;
+  StartTime = 0;
   StopTime = 0;
   UpTime = 0;
   CurrMaxUpTime = MaxUpTime;
+  LastLoopMillis = millis();  // FIX: preserve millis() reference to avoid jump in UpTime calculation
 }
 
 //Clear "UpTimeError" error flag and allow the pump to run for an extra MaxUpTime

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -30,7 +30,7 @@ void Pump::loop()
 
   if(IsRunning())
   {
-    if (loopHandler) loopHandler(); // Appel du handler a chaque boucle
+    if (loopHandler) loopHandler(); // Appel du handler à chaque boucle
 
     UpTime += millis() - LastLoopMillis;
     LastLoopMillis = millis();
@@ -69,8 +69,8 @@ u_int8_t Pump::Start(bool _resetUpTime)
   bitMaskErrors |= (!CheckInterlock() & 1) << 2; // Bit 2: Interlock error
 
 #ifdef KC868_A8
-  Serial.printf("[Pump::Start] pin=%d isRunning=%d UpTimeError=%d TankLevel=%d Interlock=%d bits=0x%02X\r\n",
-    this->GetPinId(), IsRunning(), UpTimeError, TankLevel(), CheckInterlock(), bitMaskErrors);
+  Serial.printf("[Pump::Start] pin=%d isRunning=%d UpTimeErr=%d Tank=%d Interlock=%d bits=0x%02X\r\n",
+    GetPinNumber(), IsRunning(), UpTimeError, TankLevel(), CheckInterlock(), bitMaskErrors);
 #endif
 
   if((!IsRunning()) && !UpTimeError && TankLevel() && CheckInterlock())
@@ -79,13 +79,13 @@ u_int8_t Pump::Start(bool _resetUpTime)
       bitMaskErrors |= (1 << 3); // Bit 3: Relay error
 #ifdef KC868_A8
       Serial.printf("[Pump::Start] pin=%d Relay Enable FAILED! bits=0x%02X\r\n",
-        this->GetPinId(), bitMaskErrors);
+        GetPinNumber(), bitMaskErrors);
 #endif
       return bitMaskErrors;
     } else {
       LastLoopMillis = StartTime = millis(); 
 #ifdef KC868_A8
-      Serial.printf("[Pump::Start] pin=%d Pump STARTED OK\r\n", this->GetPinId());
+      Serial.printf("[Pump::Start] pin=%d Pump STARTED OK\r\n", GetPinNumber());
 #endif
     }
   }

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -30,7 +30,7 @@ void Pump::loop()
 
   if(IsRunning())
   {
-    if (loopHandler) loopHandler(); // Appel du handler à chaque boucle
+    if (loopHandler) loopHandler(); // Appel du handler a chaque boucle
 
     UpTime += millis() - LastLoopMillis;
     LastLoopMillis = millis();
@@ -68,13 +68,25 @@ u_int8_t Pump::Start(bool _resetUpTime)
   bitMaskErrors |= (!TankLevel() & 1) << 1; // Bit 1: Tank level error
   bitMaskErrors |= (!CheckInterlock() & 1) << 2; // Bit 2: Interlock error
 
+#ifdef KC868_A8
+  Serial.printf("[Pump::Start] pin=%d isRunning=%d UpTimeError=%d TankLevel=%d Interlock=%d bits=0x%02X\r\n",
+    this->GetPinId(), IsRunning(), UpTimeError, TankLevel(), CheckInterlock(), bitMaskErrors);
+#endif
+
   if((!IsRunning()) && !UpTimeError && TankLevel() && CheckInterlock())
   {
     if (!this->Relay::Enable()) {
       bitMaskErrors |= (1 << 3); // Bit 3: Relay error
+#ifdef KC868_A8
+      Serial.printf("[Pump::Start] pin=%d Relay Enable FAILED! bits=0x%02X\r\n",
+        this->GetPinId(), bitMaskErrors);
+#endif
       return bitMaskErrors;
     } else {
       LastLoopMillis = StartTime = millis(); 
+#ifdef KC868_A8
+      Serial.printf("[Pump::Start] pin=%d Pump STARTED OK\r\n", this->GetPinId());
+#endif
     }
   }
   return bitMaskErrors;
@@ -158,7 +170,7 @@ double Pump::GetTankUsage()
     double Consumption = flowrate/60.0*MinutesOfUpTime;
     PercentageUsed = Consumption/tankvolume*100.0;
   }
-  return (PercentageUsed); 
+  return (PercentageUsed);
 }
 
 //Set flow rate of the pump in Liters/hour

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -68,11 +68,6 @@ u_int8_t Pump::Start(bool _resetUpTime)
   bitMaskErrors |= (!TankLevel() & 1) << 1; // Bit 1: Tank level error
   bitMaskErrors |= (!CheckInterlock() & 1) << 2; // Bit 2: Interlock error
 
-#ifdef KC868_A8
-  Serial.printf("[Pump::Start] pin=%d isRunning=%d UpTimeErr=%d Tank=%d Interlock=%d bits=0x%02X\r\n",
-    GetPinNumber(), IsRunning(), UpTimeError, TankLevel(), CheckInterlock(), bitMaskErrors);
-#endif
-
   if((!IsRunning()) && !UpTimeError && TankLevel() && CheckInterlock())
   {
     if (!this->Relay::Enable()) {

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -69,8 +69,17 @@ u_int8_t Pump::Start(bool _resetUpTime)
   bitMaskErrors |= (!CheckInterlock() & 1) << 2; // Bit 2: Interlock error
 
 #ifdef KC868_A8
-  Serial.printf("[Pump::Start] pin=%d isRunning=%d UpTimeErr=%d Tank=%d Interlock=%d bits=0x%02X\r\n",
-    GetPinNumber(), IsRunning(), UpTimeError, TankLevel(), CheckInterlock(), bitMaskErrors);
+  // Only log when error state changes to avoid flooding serial output
+  if (bitMaskErrors != _lastLoggedBits) {
+    _lastLoggedBits = bitMaskErrors;
+    if (bitMaskErrors == 0) {
+      Serial.printf("[Pump::Start] pin=%d STARTED OK\r\n", GetPinNumber());
+    } else {
+      Serial.printf("[Pump::Start] pin=%d bits=0x%02X UpTime=%d Tank=%d Interlock=%d\r\n",
+        GetPinNumber(), bitMaskErrors,
+        (bitMaskErrors >> 0) & 1, (bitMaskErrors >> 1) & 1, (bitMaskErrors >> 2) & 1);
+    }
+  }
 #endif
 
   if((!IsRunning()) && !UpTimeError && TankLevel() && CheckInterlock())
@@ -78,15 +87,15 @@ u_int8_t Pump::Start(bool _resetUpTime)
     if (!this->Relay::Enable()) {
       bitMaskErrors |= (1 << 3); // Bit 3: Relay error
 #ifdef KC868_A8
-      Serial.printf("[Pump::Start] pin=%d Relay Enable FAILED! bits=0x%02X\r\n",
-        GetPinNumber(), bitMaskErrors);
+      if (bitMaskErrors != _lastLoggedBits) {
+        _lastLoggedBits = bitMaskErrors;
+        Serial.printf("[Pump::Start] pin=%d Relay Enable FAILED! bits=0x%02X\r\n",
+          GetPinNumber(), bitMaskErrors);
+      }
 #endif
       return bitMaskErrors;
     } else {
       LastLoopMillis = StartTime = millis(); 
-#ifdef KC868_A8
-      Serial.printf("[Pump::Start] pin=%d Pump STARTED OK\r\n", GetPinNumber());
-#endif
     }
   }
   return bitMaskErrors;

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -69,17 +69,8 @@ u_int8_t Pump::Start(bool _resetUpTime)
   bitMaskErrors |= (!CheckInterlock() & 1) << 2; // Bit 2: Interlock error
 
 #ifdef KC868_A8
-  // Only log when error state changes to avoid flooding serial output
-  if (bitMaskErrors != _lastLoggedBits) {
-    _lastLoggedBits = bitMaskErrors;
-    if (bitMaskErrors == 0) {
-      Serial.printf("[Pump::Start] pin=%d STARTED OK\r\n", GetPinNumber());
-    } else {
-      Serial.printf("[Pump::Start] pin=%d bits=0x%02X UpTime=%d Tank=%d Interlock=%d\r\n",
-        GetPinNumber(), bitMaskErrors,
-        (bitMaskErrors >> 0) & 1, (bitMaskErrors >> 1) & 1, (bitMaskErrors >> 2) & 1);
-    }
-  }
+  Serial.printf("[Pump::Start] pin=%d isRunning=%d UpTimeErr=%d Tank=%d Interlock=%d bits=0x%02X\r\n",
+    GetPinNumber(), IsRunning(), UpTimeError, TankLevel(), CheckInterlock(), bitMaskErrors);
 #endif
 
   if((!IsRunning()) && !UpTimeError && TankLevel() && CheckInterlock())
@@ -87,15 +78,15 @@ u_int8_t Pump::Start(bool _resetUpTime)
     if (!this->Relay::Enable()) {
       bitMaskErrors |= (1 << 3); // Bit 3: Relay error
 #ifdef KC868_A8
-      if (bitMaskErrors != _lastLoggedBits) {
-        _lastLoggedBits = bitMaskErrors;
-        Serial.printf("[Pump::Start] pin=%d Relay Enable FAILED! bits=0x%02X\r\n",
-          GetPinNumber(), bitMaskErrors);
-      }
+      Serial.printf("[Pump::Start] pin=%d Relay Enable FAILED! bits=0x%02X\r\n",
+        GetPinNumber(), bitMaskErrors);
 #endif
       return bitMaskErrors;
     } else {
       LastLoopMillis = StartTime = millis(); 
+#ifdef KC868_A8
+      Serial.printf("[Pump::Start] pin=%d Pump STARTED OK\r\n", GetPinNumber());
+#endif
     }
   }
   return bitMaskErrors;

--- a/lib/Pump-master/src/Pump.h
+++ b/lib/Pump-master/src/Pump.h
@@ -101,5 +101,8 @@ class Pump : public Relay {
     unsigned long LastLoopMillis     = 0;
     uint8_t tank_level_pin;
     double flowrate, tankvolume, tankfill; // Flowrate in L/h, tank volume in Liters, tank fill in %
+#ifdef KC868_A8
+    uint8_t _lastLoggedBits = 0xFF; // Track last logged error bitmask to avoid spam
+#endif
 };
 #endif

--- a/lib/Pump-master/src/Pump.h
+++ b/lib/Pump-master/src/Pump.h
@@ -101,8 +101,5 @@ class Pump : public Relay {
     unsigned long LastLoopMillis     = 0;
     uint8_t tank_level_pin;
     double flowrate, tankvolume, tankfill; // Flowrate in L/h, tank volume in Liters, tank fill in %
-#ifdef KC868_A8
-    uint8_t _lastLoggedBits = 0xFF; // Track last logged error bitmask to avoid spam
-#endif
 };
 #endif

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -37,6 +37,17 @@ void stack_mon(UBaseType_t&);
 void lockI2C();
 void unlockI2C();
 
+// Helper: log pump start errors as decoded bitmask
+static void logPumpStartErrors(const char* pumpName, uint8_t errors) {
+    if (errors == 0) return; // no errors, pump started successfully
+    Debug.print(DBG_WARNING, "[%s] Start() errors: 0x%02X | UpTime:%d Tank:%d Interlock:%d Relay:%d",
+        pumpName, errors,
+        (errors >> 0) & 1,  // Bit 0: UpTimeError
+        (errors >> 1) & 1,  // Bit 1: TankLevel error
+        (errors >> 2) & 1,  // Bit 2: Interlock error
+        (errors >> 3) & 1); // Bit 3: Relay error
+}
+
 //Update loop for ADS1115 measurements
 // Some explanations: The sampling rate is set to 16sps in order to be sure that 
 // every 125ms (which is the period of the task) there is a sample available. As it takes 3ms to
@@ -335,7 +346,7 @@ void pHRegulation(void *pvParameters)
     if (PhPID.GetMode() == AUTOMATIC)
     {  
       if (FiltrationPump.IsRunning()) {
-  
+ 
           if(PhPID.Compute()){
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f, %13.9f, %13.9f, %17.9f",PMData.PhPIDOutput,PMData.PhValue,PMData.Ph_SetPoint,PMConfig.get<double>(PH_KP));
             if(PMData.PhPIDOutput < (double)30000.) PMData.PhPIDOutput = 0.;
@@ -352,8 +363,10 @@ void pHRegulation(void *pvParameters)
             }
           if ((unsigned long)PMData.PhPIDOutput <= now - PMData.PhPIDwStart)
             PhPump.Stop();
-          else
-            PhPump.Start();   
+          else {
+            uint8_t err = PhPump.Start();
+            logPumpStartErrors("PhPump", err);
+          }
       } else {
         PhPID.SetMode(MANUAL);
         PMData.Ph_RegOnOff = false;
@@ -424,8 +437,10 @@ void OrpRegulation(void *pvParameters)
         }
         if ((unsigned long)PMData.OrpPIDOutput <= now - PMData.OrpPIDwStart)
           ChlPump.Stop();
-        else
-          ChlPump.Start();
+        else {
+          uint8_t err = ChlPump.Start();
+          logPumpStartErrors("ChlPump", err);
+        }
       } else {
         OrpPID.SetMode(MANUAL);
         PMData.Orp_RegOnOff = false;
@@ -575,22 +590,17 @@ void getTemp(void *pvParameters)
 // Runs every 60 seconds. Checks pump states and adjusts
 // simulated pH/ORP values accordingly.
 // Only active when SIMU_PH / SIMU_ORP is enabled in Config.h.
-// ============================================================
-#ifdef KC868_A8
+// ==========================================================
 void AnalogSimLoop(void *pvParameters)
 {
   while (!startTasks) ;
-  vTaskDelay(DT7);  // Scheduling offset
-
+  vTaskDelay(DT7);
+  
   TickType_t period = pdMS_TO_TICKS(60000);  // 60 seconds
   TickType_t ticktime = xTaskGetTickCount();
   static UBaseType_t hwm = 0;
 
   Debug.print(DBG_INFO, "[AnalogSim] Loop started (period: 60s)");
-  Debug.print(DBG_INFO, "[AnalogSim] pH rate: -%.3f/+%.3f per min (range: %.1f-%.1f)",
-      SIM_PH_ACTIVE_RATE, SIM_PH_DRIFT_RATE, SIM_PH_MIN, SIM_PH_MAX);
-  Debug.print(DBG_INFO, "[AnalogSim] ORP rate: +%.1f/-%.1f per min (range: %.0f-%.0f)",
-      SIM_ORP_ACTIVE_RATE, SIM_ORP_DRIFT_RATE, SIM_ORP_MIN, SIM_ORP_MAX);
 
   for(;;)
   {
@@ -599,4 +609,3 @@ void AnalogSimLoop(void *pvParameters)
     vTaskDelayUntil(&ticktime,period);
   }
 }
-#endif

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -49,20 +49,6 @@ static void logPumpStartErrors(const char* pumpName, uint8_t errors) {
 }
 
 //Update loop for ADS1115 measurements
-// Some explanations: The sampling rate is set to 16sps in order to be sure that 
-// every 125ms (which is the period of the task) there is a sample available. As it takes 3ms to
-// update and restart the ADC, the whole loop takes a minimum of 3 + 1/SPS ms. If SPS was set to 
-// 8sps, that means 128ms instead of 125ms. With 16sps, we have 3 + 62.5 < 125ms which is OK.
-// With those settings, we get a value for each channel roughly every second: 9 values asked 
-// (3 per channel), with height values retrieved per second -> 0,89 value per second. The value
-// returned for each channel is the median of the three samples. Then, among the last 11
-// samples returned, we take the 5 median ones and compute the mean as consolidated value.
-// With the "Loulou74" board, the sampling is different: we sample PSI at 8sps, and pH, Orp at 
-// 4sps each. Filtering and average is then performed as usual to get a new value every second.
-
-//We have here two sections of code here of which only one will be compiled depending on the
-//configuration 
-
 #ifdef EXT_ADS1115
 //----------------------------
 void AnalogInit()
@@ -96,25 +82,20 @@ void AnalogPoll(void *pvParameters)
     lockI2C();
     adc_ext.update();
 
-    if(adc_ext.ready()){                              // all conversions done ?
-      // As an int is 32 bits long for ESP32 and as the ADS1115 is wired in differential, we have to manage
-      // negative voltage as follow
+    if(adc_ext.ready()){
       orp_sensor_value = adc_ext.readFilter(0);
-      if(orp_sensor_value >= 32768) orp_sensor_value = orp_sensor_value - 65536;  // ORP sensor current value
+      if(orp_sensor_value >= 32768) orp_sensor_value = orp_sensor_value - 65536;
       ph_sensor_value = adc_ext.readFilter(1);
-      if(ph_sensor_value >= 32768) ph_sensor_value= ph_sensor_value - 65536;      // pH sensor current value
+      if(ph_sensor_value >= 32768) ph_sensor_value= ph_sensor_value - 65536;
       adc_ext.start();  
         
-      //Ph
-      samples_Ph.add(ph_sensor_value);          // compute average of pH from center 5 measurements among 11
+      samples_Ph.add(ph_sensor_value);
       PMData.PhValue = (samples_Ph.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PHCALIBCOEFFS0) + PMConfig.get<double>(PHCALIBCOEFFS1);
 
-      //ORP
-      samples_Orp.add(orp_sensor_value);        // compute average of ORP from last 5 measurements
+      samples_Orp.add(orp_sensor_value);
       PMData.OrpValue = (samples_Orp.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(ORPCALIBCOEFFS0) + PMConfig.get<double>(ORPCALIBCOEFFS1);
 
 #ifdef KC868_A8
-      // Override with simulated values when simulation is active
       double simPH = SimSensor.getSimulatedValue(SimSensor.SENSOR_PH);
       if (!isnan(simPH)) PMData.PhValue = simPH;
       double simORP = SimSensor.getSimulatedValue(SimSensor.SENSOR_ORP);
@@ -128,16 +109,14 @@ void AnalogPoll(void *pvParameters)
     adc_int.update();
 
     if(adc_int.ready()){
-      psi_sensor_value = adc_int.readFilter(0) ;    // psi sensor current value
+      psi_sensor_value = adc_int.readFilter(0) ;
       adc_int.start();
 
-      //PSI (water pressure)
-      samples_PSI.add(psi_sensor_value);        // compute average of PSI from last 5 measurements
+      samples_PSI.add(psi_sensor_value);
       PMData.PSIValue = (samples_PSI.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PSICALIBCOEFFS0) + PMConfig.get<double>(PSICALIBCOEFFS1);
       PMData.PSIValue = (PMData.PSIValue < 0)? 0 : PMData.PSIValue;
 
 #ifdef KC868_A8
-      // Override with simulated value when simulation is active
       double simPSI = SimSensor.getSimulatedValue(SimSensor.SENSOR_PSI);
       if (!isnan(simPSI)) PMData.PSIValue = simPSI;
 #endif
@@ -190,28 +169,23 @@ void AnalogPoll(void *pvParameters)
     lockI2C();
     adc_int.update();
 
-    if(adc_int.ready()){                              // all conversions done ?
-        orp_sensor_value = adc_int.readFilter(0) ;    // ORP sensor current value
-        ph_sensor_value  = adc_int.readFilter(1) ;    // pH sensor current value
-        psi_sensor_value = adc_int.readFilter(2) ;    // psi sensor current value
+    if(adc_int.ready()){
+        orp_sensor_value = adc_int.readFilter(0) ;
+        ph_sensor_value  = adc_int.readFilter(1) ;
+        psi_sensor_value = adc_int.readFilter(2) ;
         adc_int.start();  
         
-        //Ph
-        samples_Ph.add(ph_sensor_value);          // compute average of pH from center 5 measurements among 11
+        samples_Ph.add(ph_sensor_value);
         PMData.PhValue = (samples_Ph.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PHCALIBCOEFFS0) + PMConfig.get<double>(PHCALIBCOEFFS1);
 
-        //ORP
-        samples_Orp.add(orp_sensor_value);        // compute average of ORP from last 5 measurements
+        samples_Orp.add(orp_sensor_value);
         PMData.OrpValue = (samples_Orp.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(ORPCALIBCOEFFS0) + PMConfig.get<double>(ORPCALIBCOEFFS1);
 
-        //PSI (water pressure)
-        samples_PSI.add(psi_sensor_value);        // compute average of PSI from last 5 measurements
+        samples_PSI.add(psi_sensor_value);
         PMData.PSIValue = (samples_PSI.getAverage(5)*0.1875/1000.)*PMConfig.get<double>(PSICALIBCOEFFS0) + PMConfig.get<double>(PSICALIBCOEFFS1);
         PMData.PSIValue = (PMData.PSIValue < 0)? 0 : PMData.PSIValue;
 
 #ifdef KC868_A8
-        // Override with simulated values when simulation is active
-        // This must happen after calibration
         double simPH = SimSensor.getSimulatedValue(SimSensor.SENSOR_PH);
         if (!isnan(simPH)) PMData.PhValue = simPH;
         double simORP = SimSensor.getSimulatedValue(SimSensor.SENSOR_ORP);
@@ -219,8 +193,6 @@ void AnalogPoll(void *pvParameters)
         double simPSI = SimSensor.getSimulatedValue(SimSensor.SENSOR_PSI);
         if (!isnan(simPSI)) PMData.PSIValue = simPSI;
 #endif
-
-
 
         Debug.print(DBG_DEBUG,"pH: %5.0f - %4.2f - ORP: %5.0f - %3.0fmV - PSI: %5.0f - %4.2fBar\r",
             ph_sensor_value,PMData.PhValue,orp_sensor_value,PMData.OrpValue,psi_sensor_value,PMData.PSIValue);
@@ -328,21 +300,9 @@ void pHRegulation(void *pvParameters)
   TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm = 0;
 
-  #ifdef CHRONO
-  unsigned long td;
-  int t_act=0,t_min=999,t_max=0;
-  float t_mean=0.;
-  int n=1;
-  #endif
-
   for(;;)
   {
-    #ifdef CHRONO
-    td = millis();
-    #endif 
-
     //do not compute PID if filtration pump is not running
-    // Set also a lower limit at 30s (a lower pump duration doesn't mean anything)
     if (PhPID.GetMode() == AUTOMATIC)
     {  
       if (FiltrationPump.IsRunning()) {
@@ -356,20 +316,20 @@ void pHRegulation(void *pvParameters)
            turn the Acid pump on/off based on pid output
           ************************************************/
           unsigned long now = millis();
+          unsigned long wSize = PMConfig.get<unsigned long>(PHPIDWINDOWSIZE);
           Debug.print(DBG_INFO,"[pHReg] now=%lu wStart=%lu wSize=%lu output=%lu",
-            now, PMData.PhPIDwStart, PMConfig.get<unsigned long>(PHPIDWINDOWSIZE),
-            (unsigned long)PMData.PhPIDOutput);
-          if (now - PMData.PhPIDwStart > PMConfig.get<unsigned long>(PHPIDWINDOWSIZE))
+            now, PMData.PhPIDwStart, wSize, (unsigned long)PMData.PhPIDOutput);
+          if (now - PMData.PhPIDwStart > wSize)
           {
             //time to shift the Relay Window
-            PMData.PhPIDwStart += PMConfig.get<double>(PHPIDWINDOWSIZE);
+            PMData.PhPIDwStart += wSize;
             Debug.print(DBG_INFO,"[pHReg] Window shifted to %lu", PMData.PhPIDwStart);
             }
           if ((unsigned long)PMData.PhPIDOutput <= now - PMData.PhPIDwStart) {
-            Debug.print(DBG_INFO,"[pHReg] STOP (output <= elapsed)");
+            Debug.print(DBG_INFO,"[pHReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
             PhPump.Stop();
           } else {
-            Debug.print(DBG_INFO,"[pHReg] START (output > elapsed)");
+            Debug.print(DBG_INFO,"[pHReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
             uint8_t err = PhPump.Start();
             logPumpStartErrors("PhPump", err);
           }
@@ -380,15 +340,6 @@ void pHRegulation(void *pvParameters)
         PhPump.Stop();
       } 
     }
-
- #ifdef CHRONO
-    t_act = millis() - td;
-    if(t_act > t_max) t_max = t_act;
-    if(t_act < t_min) t_min = t_act;
-    t_mean += (t_act - t_mean)/n;
-    ++n;
-    Debug.print(DBG_INFO,"[pHRegulation] td: %d t_act: %d t_min: %d t_max: %d t_mean: %4.1f",td,t_act,t_min,t_max,t_mean);
-    #endif
 
     stack_mon(hwm);
     vTaskDelayUntil(&ticktime,period);
@@ -405,21 +356,9 @@ void OrpRegulation(void *pvParameters)
   TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm = 0;
 
-  #ifdef CHRONO
-  unsigned long td;
-  int t_act=0,t_min=999,t_max=0;
-  float t_mean=0.;
-  int n=1;
-  #endif
-
   for(;;)
   { 
-    #ifdef CHRONO
-    td = millis();
-    #endif 
-
     //do not compute PID if filtration pump is not running
-    // Set also a lower limit at 30s (a lower pump duration does'nt mean anything)
     if (OrpPID.GetMode() == AUTOMATIC) {
       if (FiltrationPump.IsRunning())
       {
@@ -432,20 +371,20 @@ void OrpRegulation(void *pvParameters)
          turn the Chl pump on/off based on pid output
         ************************************************/
         unsigned long now = millis();
+        unsigned long wSize = PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE);
         Debug.print(DBG_INFO,"[OrpReg] now=%lu wStart=%lu wSize=%lu output=%lu",
-          now, PMData.OrpPIDwStart, PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE),
-          (unsigned long)PMData.OrpPIDOutput);
-        if (now - PMData.OrpPIDwStart > PMConfig.get<double>(ORPPIDWINDOWSIZE))
+          now, PMData.OrpPIDwStart, wSize, (unsigned long)PMData.OrpPIDOutput);
+        if (now - PMData.OrpPIDwStart > wSize)
         {
           //time to shift the Relay Window
-          PMData.OrpPIDwStart += PMConfig.get<double>(ORPPIDWINDOWSIZE);
+          PMData.OrpPIDwStart += wSize;
           Debug.print(DBG_INFO,"[OrpReg] Window shifted to %lu", PMData.OrpPIDwStart);
         }
         if ((unsigned long)PMData.OrpPIDOutput <= now - PMData.OrpPIDwStart) {
-          Debug.print(DBG_INFO,"[OrpReg] STOP (output <= elapsed)");
+          Debug.print(DBG_INFO,"[OrpReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
           ChlPump.Stop();
         } else {
-          Debug.print(DBG_INFO,"[OrpReg] START (output > elapsed)");
+          Debug.print(DBG_INFO,"[OrpReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
           uint8_t err = ChlPump.Start();
           logPumpStartErrors("ChlPump", err);
         }
@@ -457,15 +396,6 @@ void OrpRegulation(void *pvParameters)
       } 
     }
 
-    #ifdef CHRONO
-    t_act = millis() - td;
-    if(t_act > t_max) t_max = t_act;
-    if(t_act < t_min) t_min = t_act;
-    t_mean += (t_act - t_mean)/n;
-    ++n;
-    Debug.print(DBG_INFO,"[OrpRegulation] td: %d t_act: %d t_min: %d t_max: %d t_mean: %4.1f",td,t_act,t_min,t_max,t_mean);
-    #endif
-
     stack_mon(hwm);    
     vTaskDelayUntil(&ticktime,period);
   }
@@ -476,9 +406,8 @@ void TempInit()
 {
   bool error = false;
   char buf[64];
-  // Start up the library
   sensors_W.begin();
-  sensors_W.begin(); // two times to work-around of a OneWire library bug for enumeration
+  sensors_W.begin();
   sensors_A.begin();
 
   Debug.print(DBG_INFO,"1wire W devices: %d device(s) found",sensors_W.getDeviceCount());
@@ -521,18 +450,14 @@ void TempInit()
 
   if(!error) 
   {
-    // set the resolution
     sensors_W.setResolution(DS18B20_W, TEMPERATURE_RESOLUTION);
     sensors_A.setResolution(DS18B20_A, TEMPERATURE_RESOLUTION);
-
-    //don't wait ! Asynchronous mode
     sensors_W.setWaitForConversion(false);
     sensors_A.setWaitForConversion(false);
   }
 }
 
 //Request temperature asynchronously
-//in case of reading error, the buffer is not updated and the last value is kept
 void getTemp(void *pvParameters)
 {
   while (!startTasks) ;
@@ -542,23 +467,12 @@ void getTemp(void *pvParameters)
   TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm = 0;
 
-  #ifdef CHRONO
-  unsigned long td;
-  int t_act=0,t_min=999,t_max=0;
-  float t_mean=0.;
-  int n=1;
-  #endif
-
   sensors_W.requestTemperatures();
   sensors_A.requestTemperatures();
   vTaskDelayUntil(&ticktime,period);
   
   for(;;)
   {        
-    #ifdef CHRONO
-    td = millis();
-    #endif 
-
     double temp = sensors_W.getTempC(DS18B20_W);
     if (temp == NAN || temp == -127) {
       Debug.print(DBG_WARNING,"Error getting Water temperature");
@@ -578,15 +492,6 @@ void getTemp(void *pvParameters)
     sensors_W.requestTemperatures();
     sensors_A.requestTemperatures();
 
-    #ifdef CHRONO
-    t_act = millis() - td;
-    if(t_act > t_max) t_max = t_act;
-    if(t_act < t_min) t_min = t_act;
-    t_mean += (t_act - t_mean)/n;
-    ++n;
-    Debug.print(DBG_INFO,"[getTemp] td: %d t_act: %d t_min: %d t_max: %d t_mean: %4.1f",td,t_act,t_min,t_max,t_mean);
-    #endif
-
     stack_mon(hwm);
     vTaskDelayUntil(&ticktime,period);
   } 
@@ -594,10 +499,6 @@ void getTemp(void *pvParameters)
 
 // ============================================================
 // Analog Sensor Simulation Loop (KC868-A8 only)
-// ============================================================
-// Runs every 60 seconds. Checks pump states and adjusts
-// simulated pH/ORP values accordingly.
-// Only active when SIMU_PH / SIMU_ORP is enabled in Config.h.
 // ==========================================================
 void AnalogSimLoop(void *pvParameters)
 {

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -37,26 +37,15 @@ void stack_mon(UBaseType_t&);
 void lockI2C();
 void unlockI2C();
 
-// Helper: log pump start errors — only on state change to avoid spam
+// Helper: log pump start errors as decoded bitmask
 static void logPumpStartErrors(const char* pumpName, uint8_t errors) {
-    static uint8_t lastErrPh  = 0xFF; // track PhPump state
-    static uint8_t lastErrChl = 0xFF; // track ChlPump state
-
-    uint8_t &lastErr = (strcmp(pumpName, "PhPump") == 0) ? lastErrPh : lastErrChl;
-
-    if (errors == lastErr) return;  // no change — skip
-    lastErr = errors;
-
-    if (errors == 0) {
-        Debug.print(DBG_INFO, "[%s] Start OK", pumpName);
-    } else {
-        Debug.print(DBG_WARNING, "[%s] Start errors: 0x%02X | UpTime:%d Tank:%d Interlock:%d Relay:%d",
-            pumpName, errors,
-            (errors >> 0) & 1,  // Bit 0: UpTimeError
-            (errors >> 1) & 1,  // Bit 1: TankLevel error
-            (errors >> 2) & 1,  // Bit 2: Interlock error
-            (errors >> 3) & 1); // Bit 3: Relay error
-    }
+    if (errors == 0) return; // no errors, pump started successfully
+    Debug.print(DBG_WARNING, "[%s] Start() errors: 0x%02X | UpTime:%d Tank:%d Interlock:%d Relay:%d",
+        pumpName, errors,
+        (errors >> 0) & 1,  // Bit 0: UpTimeError
+        (errors >> 1) & 1,  // Bit 1: TankLevel error
+        (errors >> 2) & 1,  // Bit 2: Interlock error
+        (errors >> 3) & 1); // Bit 3: Relay error
 }
 
 #ifdef EXT_ADS1115
@@ -112,7 +101,7 @@ void AnalogPoll(void *pvParameters)
       if (!isnan(simORP)) PMData.OrpValue = simORP;
 #endif
 
-      Debug.print(DBG_DEBUG,"pH: %5.0f - %4.2f - ORP: %5.0f - %3.0fmV - PSI: %5.0f - %4.2fBar\r",
+      Debug.print(DBG_DEBUG,"pH: %5.0f - %4.2f - ORP: %5.0f - %3.0fmV - PSI: %5.0f - %4.2fBar\r\n",
         ph_sensor_value,PMData.PhValue,orp_sensor_value,PMData.OrpValue,psi_sensor_value,PMData.PSIValue);
     }
     
@@ -158,6 +147,13 @@ void AnalogPoll(void *pvParameters)
   TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm=0;
 
+  #ifdef CHRONO
+  unsigned long td;
+  int t_act=0,t_min=999,t_max=0;
+  float t_mean=0.;
+  int n=1;
+  #endif
+
   lockI2C();
   adc_int.start();
   unlockI2C();
@@ -165,6 +161,10 @@ void AnalogPoll(void *pvParameters)
   
   for(;;)
   {
+    #ifdef CHRONO
+    td = millis();
+    #endif
+
     lockI2C();
     adc_int.update();
 
@@ -193,7 +193,7 @@ void AnalogPoll(void *pvParameters)
         if (!isnan(simPSI)) PMData.PSIValue = simPSI;
 #endif
 
-        Debug.print(DBG_DEBUG,"pH: %5.0f - %4.2f - ORP: %5.0f - %3.0fmV - PSI: %5.0f - %4.2fBar\r",
+        Debug.print(DBG_DEBUG,"pH: %5.0f - %4.2f - ORP: %5.0f - %3.0fmV - PSI: %5.0f - %4.2fBar\r\n",
             ph_sensor_value,PMData.PhValue,orp_sensor_value,PMData.OrpValue,psi_sensor_value,PMData.PSIValue);
     }
     unlockI2C();

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -281,29 +281,26 @@ void pHRegulation(void *pvParameters)
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f, %13.9f, %13.9f, %17.9f",PMData.PhPIDOutput,PMData.PhValue,PMData.Ph_SetPoint,PMConfig.get<double>(PH_KP));
             if(PMData.PhPIDOutput < (double)30000.) PMData.PhPIDOutput = 0.;
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f",PMData.PhPIDOutput);
+          }    
 
-            /************************************************
-             turn the Acid pump on/off based on pid output
-            ************************************************/
-            unsigned long now = millis();
-            unsigned long wSize = PMConfig.get<unsigned long>(PHPIDWINDOWSIZE);
-            
-            // Reset relay window start to now - this ensures the window
-            // always starts fresh when PID computes a new output value
-            PMData.PhPIDwStart = now;
-            
-            Debug.print(DBG_INFO,"[pHReg] now=%lu output=%lu wSize=%lu",
-              now, (unsigned long)PMData.PhPIDOutput, wSize);
-            
-            if (PMData.PhPIDOutput < 1.0) {
-              // PID output is zero (below threshold) - pump off
-              Debug.print(DBG_INFO,"[pHReg] STOP (output=0)");
-              PhPump.Stop();
-            } else {
-              Debug.print(DBG_INFO,"[pHReg] START (output=%lu > 0)", (unsigned long)PMData.PhPIDOutput);
-              uint8_t err = PhPump.Start();
-              logPumpStartErrors("PhPump", err);
-            }
+          /************************************************
+           turn the Acid pump on/off based on pid output
+          ************************************************/
+          unsigned long now = millis();
+          unsigned long wSize = PMConfig.get<unsigned long>(PHPIDWINDOWSIZE);
+          if (now - PMData.PhPIDwStart > wSize)
+          {
+            //time to shift the Relay Window
+            PMData.PhPIDwStart += wSize;
+            Debug.print(DBG_INFO,"[pHReg] Window shifted, output=%lu", (unsigned long)PMData.PhPIDOutput);
+          }
+          if ((unsigned long)PMData.PhPIDOutput <= now - PMData.PhPIDwStart) {
+            Debug.print(DBG_INFO,"[pHReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
+            PhPump.Stop();
+          } else {
+            Debug.print(DBG_INFO,"[pHReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
+            uint8_t err = PhPump.Start();
+            logPumpStartErrors("PhPump", err);
           }
       } else {
         PhPID.SetMode(MANUAL);
@@ -338,27 +335,26 @@ void OrpRegulation(void *pvParameters)
           Debug.print(DBG_INFO,"ORP regulation: %10.2f, %13.9f, %12.9f, %17.9f",PMData.OrpPIDOutput,PMData.OrpValue,PMData.Orp_SetPoint,PMConfig.get<double>(ORP_KP));
           if(PMData.OrpPIDOutput < (double)30000.) PMData.OrpPIDOutput = 0.;    
             Debug.print(DBG_INFO,"Orp regulation: %10.2f",PMData.OrpPIDOutput);
+          }    
 
-          /************************************************
-           turn the Chl pump on/off based on pid output
-          ************************************************/
-          unsigned long now = millis();
-          unsigned long wSize = PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE);
-          
-          // Reset relay window start to now
-          PMData.OrpPIDwStart = now;
-          
-          Debug.print(DBG_INFO,"[OrpReg] now=%lu output=%lu wSize=%lu",
-            now, (unsigned long)PMData.OrpPIDOutput, wSize);
-          
-          if (PMData.OrpPIDOutput < 1.0) {
-            Debug.print(DBG_INFO,"[OrpReg] STOP (output=0)");
-            ChlPump.Stop();
-          } else {
-            Debug.print(DBG_INFO,"[OrpReg] START (output=%lu > 0)", (unsigned long)PMData.OrpPIDOutput);
-            uint8_t err = ChlPump.Start();
-            logPumpStartErrors("ChlPump", err);
-          }
+        /************************************************
+         turn the Chl pump on/off based on pid output
+        ************************************************/
+        unsigned long now = millis();
+        unsigned long wSize = PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE);
+        if (now - PMData.OrpPIDwStart > wSize)
+        {
+          //time to shift the Relay Window
+          PMData.OrpPIDwStart += wSize;
+          Debug.print(DBG_INFO,"[OrpReg] Window shifted, output=%lu", (unsigned long)PMData.OrpPIDOutput);
+        }
+        if ((unsigned long)PMData.OrpPIDOutput <= now - PMData.OrpPIDwStart) {
+          Debug.print(DBG_INFO,"[OrpReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
+          ChlPump.Stop();
+        } else {
+          Debug.print(DBG_INFO,"[OrpReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
+          uint8_t err = ChlPump.Start();
+          logPumpStartErrors("ChlPump", err);
         }
       } else {
         OrpPID.SetMode(MANUAL);

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -9,7 +9,7 @@
 // Setup oneWire instances to communicate with temperature sensors (one bus per sensor)
 static OneWire oneWire_W(ONE_WIRE_BUS_W);
 static OneWire oneWire_A(ONE_WIRE_BUS_A);
-// Pass our oneWire reference to Dallas Temperature library instance
+// Pass our OneWire reference to Dallas Temperature library instance
 static DallasTemperature sensors_W(&oneWire_W);
 static DallasTemperature sensors_A(&oneWire_A);
 // MAC Addresses of DS18b20 water & Air temperature sensor
@@ -37,15 +37,26 @@ void stack_mon(UBaseType_t&);
 void lockI2C();
 void unlockI2C();
 
-// Helper: log pump start errors as decoded bitmask
+// Helper: log pump start errors — only on state change to avoid spam
 static void logPumpStartErrors(const char* pumpName, uint8_t errors) {
-    if (errors == 0) return; // no errors, pump started successfully
-    Debug.print(DBG_WARNING, "[%s] Start() errors: 0x%02X | UpTime:%d Tank:%d Interlock:%d Relay:%d",
-        pumpName, errors,
-        (errors >> 0) & 1,  // Bit 0: UpTimeError
-        (errors >> 1) & 1,  // Bit 1: TankLevel error
-        (errors >> 2) & 1,  // Bit 2: Interlock error
-        (errors >> 3) & 1); // Bit 3: Relay error
+    static uint8_t lastErrPh  = 0xFF; // track PhPump state
+    static uint8_t lastErrChl = 0xFF; // track ChlPump state
+
+    uint8_t &lastErr = (strcmp(pumpName, "PhPump") == 0) ? lastErrPh : lastErrChl;
+
+    if (errors == lastErr) return;  // no change — skip
+    lastErr = errors;
+
+    if (errors == 0) {
+        Debug.print(DBG_INFO, "[%s] Start OK", pumpName);
+    } else {
+        Debug.print(DBG_WARNING, "[%s] Start errors: 0x%02X | UpTime:%d Tank:%d Interlock:%d Relay:%d",
+            pumpName, errors,
+            (errors >> 0) & 1,  // Bit 0: UpTimeError
+            (errors >> 1) & 1,  // Bit 1: TankLevel error
+            (errors >> 2) & 1,  // Bit 2: Interlock error
+            (errors >> 3) & 1); // Bit 3: Relay error
+    }
 }
 
 #ifdef EXT_ADS1115
@@ -147,13 +158,6 @@ void AnalogPoll(void *pvParameters)
   TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm=0;
 
-  #ifdef CHRONO
-  unsigned long td;
-  int t_act=0,t_min=999,t_max=0;
-  float t_mean=0.;
-  int n=1;
-  #endif
-
   lockI2C();
   adc_int.start();
   unlockI2C();
@@ -161,10 +165,6 @@ void AnalogPoll(void *pvParameters)
   
   for(;;)
   {
-    #ifdef CHRONO
-    td = millis();
-    #endif
-
     lockI2C();
     adc_int.update();
 

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -280,7 +280,6 @@ void pHRegulation(void *pvParameters)
           if(PhPID.Compute()){
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f, %13.9f, %13.9f, %17.9f",PMData.PhPIDOutput,PMData.PhValue,PMData.Ph_SetPoint,PMConfig.get<double>(PH_KP));
             if(PMData.PhPIDOutput < (double)30000.) PMData.PhPIDOutput = 0.;
-            Debug.print(DBG_INFO,"Ph  regulation: %10.2f",PMData.PhPIDOutput);
           }    
 
           /************************************************
@@ -292,13 +291,10 @@ void pHRegulation(void *pvParameters)
           {
             //time to shift the Relay Window
             PMData.PhPIDwStart += wSize;
-            Debug.print(DBG_INFO,"[pHReg] Window shifted, output=%lu", (unsigned long)PMData.PhPIDOutput);
           }
           if ((unsigned long)PMData.PhPIDOutput <= now - PMData.PhPIDwStart) {
-            Debug.print(DBG_INFO,"[pHReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
             PhPump.Stop();
           } else {
-            Debug.print(DBG_INFO,"[pHReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
             uint8_t err = PhPump.Start();
             logPumpStartErrors("PhPump", err);
           }
@@ -334,7 +330,6 @@ void OrpRegulation(void *pvParameters)
         if(OrpPID.Compute()){
           Debug.print(DBG_INFO,"ORP regulation: %10.2f, %13.9f, %12.9f, %17.9f",PMData.OrpPIDOutput,PMData.OrpValue,PMData.Orp_SetPoint,PMConfig.get<double>(ORP_KP));
           if(PMData.OrpPIDOutput < (double)30000.) PMData.OrpPIDOutput = 0.;    
-            Debug.print(DBG_INFO,"Orp regulation: %10.2f",PMData.OrpPIDOutput);
           }    
 
         /************************************************
@@ -346,13 +341,10 @@ void OrpRegulation(void *pvParameters)
         {
           //time to shift the Relay Window
           PMData.OrpPIDwStart += wSize;
-          Debug.print(DBG_INFO,"[OrpReg] Window shifted, output=%lu", (unsigned long)PMData.OrpPIDOutput);
         }
         if ((unsigned long)PMData.OrpPIDOutput <= now - PMData.OrpPIDwStart) {
-          Debug.print(DBG_INFO,"[OrpReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
           ChlPump.Stop();
         } else {
-          Debug.print(DBG_INFO,"[OrpReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
           uint8_t err = ChlPump.Start();
           logPumpStartErrors("ChlPump", err);
         }

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -356,14 +356,20 @@ void pHRegulation(void *pvParameters)
            turn the Acid pump on/off based on pid output
           ************************************************/
           unsigned long now = millis();
+          Debug.print(DBG_INFO,"[pHReg] now=%lu wStart=%lu wSize=%lu output=%lu",
+            now, PMData.PhPIDwStart, PMConfig.get<unsigned long>(PHPIDWINDOWSIZE),
+            (unsigned long)PMData.PhPIDOutput);
           if (now - PMData.PhPIDwStart > PMConfig.get<unsigned long>(PHPIDWINDOWSIZE))
           {
             //time to shift the Relay Window
             PMData.PhPIDwStart += PMConfig.get<double>(PHPIDWINDOWSIZE);
+            Debug.print(DBG_INFO,"[pHReg] Window shifted to %lu", PMData.PhPIDwStart);
             }
-          if ((unsigned long)PMData.PhPIDOutput <= now - PMData.PhPIDwStart)
+          if ((unsigned long)PMData.PhPIDOutput <= now - PMData.PhPIDwStart) {
+            Debug.print(DBG_INFO,"[pHReg] STOP (output <= elapsed)");
             PhPump.Stop();
-          else {
+          } else {
+            Debug.print(DBG_INFO,"[pHReg] START (output > elapsed)");
             uint8_t err = PhPump.Start();
             logPumpStartErrors("PhPump", err);
           }
@@ -375,11 +381,7 @@ void pHRegulation(void *pvParameters)
       } 
     }
 
- unsigned long PhPIDwStart, OrpPIDwStart;
-    double AirTemp;
-    double PhPIDOutput, OrpPIDOutput;
-
-    #ifdef CHRONO
+ #ifdef CHRONO
     t_act = millis() - td;
     if(t_act > t_max) t_max = t_act;
     if(t_act < t_min) t_min = t_act;
@@ -430,14 +432,20 @@ void OrpRegulation(void *pvParameters)
          turn the Chl pump on/off based on pid output
         ************************************************/
         unsigned long now = millis();
+        Debug.print(DBG_INFO,"[OrpReg] now=%lu wStart=%lu wSize=%lu output=%lu",
+          now, PMData.OrpPIDwStart, PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE),
+          (unsigned long)PMData.OrpPIDOutput);
         if (now - PMData.OrpPIDwStart > PMConfig.get<double>(ORPPIDWINDOWSIZE))
         {
           //time to shift the Relay Window
           PMData.OrpPIDwStart += PMConfig.get<double>(ORPPIDWINDOWSIZE);
+          Debug.print(DBG_INFO,"[OrpReg] Window shifted to %lu", PMData.OrpPIDwStart);
         }
-        if ((unsigned long)PMData.OrpPIDOutput <= now - PMData.OrpPIDwStart)
+        if ((unsigned long)PMData.OrpPIDOutput <= now - PMData.OrpPIDwStart) {
+          Debug.print(DBG_INFO,"[OrpReg] STOP (output <= elapsed)");
           ChlPump.Stop();
-        else {
+        } else {
+          Debug.print(DBG_INFO,"[OrpReg] START (output > elapsed)");
           uint8_t err = ChlPump.Start();
           logPumpStartErrors("ChlPump", err);
         }
@@ -597,7 +605,7 @@ void AnalogSimLoop(void *pvParameters)
   vTaskDelay(DT7);
   
   TickType_t period = pdMS_TO_TICKS(60000);  // 60 seconds
-  TickType_t ticktime = xTaskGetTickCount();
+  TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm = 0;
 
   Debug.print(DBG_INFO, "[AnalogSim] Loop started (period: 60s)");

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -79,7 +79,7 @@ void AnalogPoll(void *pvParameters)
   for(;;)
   {
     lockI2C();
-  adc_ext.update();
+    adc_ext.update();
 
     if(adc_ext.ready()){
       orp_sensor_value = adc_ext.readFilter(0);
@@ -287,19 +287,20 @@ void pHRegulation(void *pvParameters)
             ************************************************/
             unsigned long now = millis();
             unsigned long wSize = PMConfig.get<unsigned long>(PHPIDWINDOWSIZE);
-            Debug.print(DBG_INFO,"[pHReg] now=%lu wStart=%lu wSize=%lu output=%lu",
-              now, PMData.PhPIDwStart, wSize, (unsigned long)PMData.PhPIDOutput);
-            if (now - PMData.PhPIDwStart > wSize)
-            {
-              //time to shift the Relay Window
-              PMData.PhPIDwStart += wSize;
-              Debug.print(DBG_INFO,"[pHReg] Window shifted to %lu", PMData.PhPIDwStart);
-            }
-            if ((unsigned long)PMData.PhPIDOutput <= now - PMData.PhPIDwStart) {
-              Debug.print(DBG_INFO,"[pHReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
+            
+            // Reset relay window start to now - this ensures the window
+            // always starts fresh when PID computes a new output value
+            PMData.PhPIDwStart = now;
+            
+            Debug.print(DBG_INFO,"[pHReg] now=%lu output=%lu wSize=%lu",
+              now, (unsigned long)PMData.PhPIDOutput, wSize);
+            
+            if (PMData.PhPIDOutput < 1.0) {
+              // PID output is zero (below threshold) - pump off
+              Debug.print(DBG_INFO,"[pHReg] STOP (output=0)");
               PhPump.Stop();
             } else {
-              Debug.print(DBG_INFO,"[pHReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
+              Debug.print(DBG_INFO,"[pHReg] START (output=%lu > 0)", (unsigned long)PMData.PhPIDOutput);
               uint8_t err = PhPump.Start();
               logPumpStartErrors("PhPump", err);
             }
@@ -343,19 +344,18 @@ void OrpRegulation(void *pvParameters)
           ************************************************/
           unsigned long now = millis();
           unsigned long wSize = PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE);
-          Debug.print(DBG_INFO,"[OrpReg] now=%lu wStart=%lu wSize=%lu output=%lu",
-            now, PMData.OrpPIDwStart, wSize, (unsigned long)PMData.OrpPIDOutput);
-          if (now - PMData.OrpPIDwStart > wSize)
-          {
-            //time to shift the Relay Window
-            PMData.OrpPIDwStart += wSize;
-            Debug.print(DBG_INFO,"[OrpReg] Window shifted to %lu", PMData.OrpPIDwStart);
-          }
-          if ((unsigned long)PMData.OrpPIDOutput <= now - PMData.OrpPIDwStart) {
-            Debug.print(DBG_INFO,"[OrpReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
+          
+          // Reset relay window start to now
+          PMData.OrpPIDwStart = now;
+          
+          Debug.print(DBG_INFO,"[OrpReg] now=%lu output=%lu wSize=%lu",
+            now, (unsigned long)PMData.OrpPIDOutput, wSize);
+          
+          if (PMData.OrpPIDOutput < 1.0) {
+            Debug.print(DBG_INFO,"[OrpReg] STOP (output=0)");
             ChlPump.Stop();
           } else {
-            Debug.print(DBG_INFO,"[OrpReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
+            Debug.print(DBG_INFO,"[OrpReg] START (output=%lu > 0)", (unsigned long)PMData.OrpPIDOutput);
             uint8_t err = ChlPump.Start();
             logPumpStartErrors("ChlPump", err);
           }

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -48,7 +48,6 @@ static void logPumpStartErrors(const char* pumpName, uint8_t errors) {
         (errors >> 3) & 1); // Bit 3: Relay error
 }
 
-//Update loop for ADS1115 measurements
 #ifdef EXT_ADS1115
 //----------------------------
 void AnalogInit()
@@ -80,7 +79,7 @@ void AnalogPoll(void *pvParameters)
   for(;;)
   {
     lockI2C();
-    adc_ext.update();
+  adc_ext.update();
 
     if(adc_ext.ready()){
       orp_sensor_value = adc_ext.readFilter(0);
@@ -199,15 +198,6 @@ void AnalogPoll(void *pvParameters)
     }
     unlockI2C();
 
-    #ifdef CHRONO
-    t_act = millis() - td;
-    if(t_act > t_max) t_max = t_act;
-    if(t_act < t_min) t_min = t_act;
-    t_mean += (t_act - t_mean)/n;
-    ++n;
-    Debug.print(DBG_INFO,"[AnalogPoll] td: %d t_act: %d t_min: %d t_max: %d t_mean: %4.1f",td,t_act,t_min,t_max,t_mean);
-    #endif 
-
     stack_mon(hwm);
     vTaskDelayUntil(&ticktime,period);
   }  
@@ -228,19 +218,8 @@ void StatusLights(void *pvParameters)
   TickType_t ticktime = xTaskGetTickCount(); 
   static UBaseType_t hwm = 0;
 
-  #ifdef CHRONO
-  unsigned long td;
-  int t_act=0,t_min=999,t_max=0;
-  float t_mean=0.;
-  int n=1;
-  #endif
-
   for(;;)
   {
-    #ifdef CHRONO
-    td = millis();
-    #endif 
-
     status = 0;
     status |= (line & 1) << 1;
     if(line == 0)
@@ -277,15 +256,6 @@ void StatusLights(void *pvParameters)
     Wire.endTransmission();
     unlockI2C();
 
-    #ifdef CHRONO
-    t_act = millis() - td;
-    if(t_act > t_max) t_max = t_act;
-    if(t_act < t_min) t_min = t_act;
-    t_mean += (t_act - t_mean)/n;
-    ++n;
-    Debug.print(DBG_INFO,"[StatusLights] td: %d t_act: %d t_min: %d t_max: %d t_mean: %4.1f",td,t_act,t_min,t_max,t_mean);
-    #endif
-
     stack_mon(hwm);
     vTaskDelayUntil(&ticktime,period);
   }
@@ -311,27 +281,28 @@ void pHRegulation(void *pvParameters)
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f, %13.9f, %13.9f, %17.9f",PMData.PhPIDOutput,PMData.PhValue,PMData.Ph_SetPoint,PMConfig.get<double>(PH_KP));
             if(PMData.PhPIDOutput < (double)30000.) PMData.PhPIDOutput = 0.;
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f",PMData.PhPIDOutput);
-          }    
-          /************************************************
-           turn the Acid pump on/off based on pid output
-          ************************************************/
-          unsigned long now = millis();
-          unsigned long wSize = PMConfig.get<unsigned long>(PHPIDWINDOWSIZE);
-          Debug.print(DBG_INFO,"[pHReg] now=%lu wStart=%lu wSize=%lu output=%lu",
-            now, PMData.PhPIDwStart, wSize, (unsigned long)PMData.PhPIDOutput);
-          if (now - PMData.PhPIDwStart > wSize)
-          {
-            //time to shift the Relay Window
-            PMData.PhPIDwStart += wSize;
-            Debug.print(DBG_INFO,"[pHReg] Window shifted to %lu", PMData.PhPIDwStart);
+
+            /************************************************
+             turn the Acid pump on/off based on pid output
+            ************************************************/
+            unsigned long now = millis();
+            unsigned long wSize = PMConfig.get<unsigned long>(PHPIDWINDOWSIZE);
+            Debug.print(DBG_INFO,"[pHReg] now=%lu wStart=%lu wSize=%lu output=%lu",
+              now, PMData.PhPIDwStart, wSize, (unsigned long)PMData.PhPIDOutput);
+            if (now - PMData.PhPIDwStart > wSize)
+            {
+              //time to shift the Relay Window
+              PMData.PhPIDwStart += wSize;
+              Debug.print(DBG_INFO,"[pHReg] Window shifted to %lu", PMData.PhPIDwStart);
             }
-          if ((unsigned long)PMData.PhPIDOutput <= now - PMData.PhPIDwStart) {
-            Debug.print(DBG_INFO,"[pHReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
-            PhPump.Stop();
-          } else {
-            Debug.print(DBG_INFO,"[pHReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
-            uint8_t err = PhPump.Start();
-            logPumpStartErrors("PhPump", err);
+            if ((unsigned long)PMData.PhPIDOutput <= now - PMData.PhPIDwStart) {
+              Debug.print(DBG_INFO,"[pHReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
+              PhPump.Stop();
+            } else {
+              Debug.print(DBG_INFO,"[pHReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.PhPIDOutput, now - PMData.PhPIDwStart);
+              uint8_t err = PhPump.Start();
+              logPumpStartErrors("PhPump", err);
+            }
           }
       } else {
         PhPID.SetMode(MANUAL);
@@ -366,27 +337,28 @@ void OrpRegulation(void *pvParameters)
           Debug.print(DBG_INFO,"ORP regulation: %10.2f, %13.9f, %12.9f, %17.9f",PMData.OrpPIDOutput,PMData.OrpValue,PMData.Orp_SetPoint,PMConfig.get<double>(ORP_KP));
           if(PMData.OrpPIDOutput < (double)30000.) PMData.OrpPIDOutput = 0.;    
             Debug.print(DBG_INFO,"Orp regulation: %10.2f",PMData.OrpPIDOutput);
-          }    
-        /************************************************
-         turn the Chl pump on/off based on pid output
-        ************************************************/
-        unsigned long now = millis();
-        unsigned long wSize = PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE);
-        Debug.print(DBG_INFO,"[OrpReg] now=%lu wStart=%lu wSize=%lu output=%lu",
-          now, PMData.OrpPIDwStart, wSize, (unsigned long)PMData.OrpPIDOutput);
-        if (now - PMData.OrpPIDwStart > wSize)
-        {
-          //time to shift the Relay Window
-          PMData.OrpPIDwStart += wSize;
-          Debug.print(DBG_INFO,"[OrpReg] Window shifted to %lu", PMData.OrpPIDwStart);
-        }
-        if ((unsigned long)PMData.OrpPIDOutput <= now - PMData.OrpPIDwStart) {
-          Debug.print(DBG_INFO,"[OrpReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
-          ChlPump.Stop();
-        } else {
-          Debug.print(DBG_INFO,"[OrpReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
-          uint8_t err = ChlPump.Start();
-          logPumpStartErrors("ChlPump", err);
+
+          /************************************************
+           turn the Chl pump on/off based on pid output
+          ************************************************/
+          unsigned long now = millis();
+          unsigned long wSize = PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE);
+          Debug.print(DBG_INFO,"[OrpReg] now=%lu wStart=%lu wSize=%lu output=%lu",
+            now, PMData.OrpPIDwStart, wSize, (unsigned long)PMData.OrpPIDOutput);
+          if (now - PMData.OrpPIDwStart > wSize)
+          {
+            //time to shift the Relay Window
+            PMData.OrpPIDwStart += wSize;
+            Debug.print(DBG_INFO,"[OrpReg] Window shifted to %lu", PMData.OrpPIDwStart);
+          }
+          if ((unsigned long)PMData.OrpPIDOutput <= now - PMData.OrpPIDwStart) {
+            Debug.print(DBG_INFO,"[OrpReg] STOP (output=%lu <= elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
+            ChlPump.Stop();
+          } else {
+            Debug.print(DBG_INFO,"[OrpReg] START (output=%lu > elapsed=%lu)", (unsigned long)PMData.OrpPIDOutput, now - PMData.OrpPIDwStart);
+            uint8_t err = ChlPump.Start();
+            logPumpStartErrors("ChlPump", err);
+          }
         }
       } else {
         OrpPID.SetMode(MANUAL);

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -587,6 +587,10 @@ void AnalogSimLoop(void *pvParameters)
   static UBaseType_t hwm = 0;
 
   Debug.print(DBG_INFO, "[AnalogSim] Loop started (period: 60s)");
+  Debug.print(DBG_INFO, "[AnalogSim] pH rate: -%.3f/+%.3f per min (range: %.1f-%.1f)",
+      SIM_PH_ACTIVE_RATE, SIM_PH_DRIFT_RATE, SIM_PH_MIN, SIM_PH_MAX);
+  Debug.print(DBG_INFO, "[AnalogSim] ORP rate: +%.1f/-%.1f per min (range: %.0f-%.0f)",
+      SIM_ORP_ACTIVE_RATE, SIM_ORP_DRIFT_RATE, SIM_ORP_MIN, SIM_ORP_MAX);
 
   for(;;)
   {

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -568,3 +568,31 @@ void getTemp(void *pvParameters)
     vTaskDelayUntil(&ticktime,period);
   } 
 }
+
+// ============================================================
+// Analog Sensor Simulation Loop (KC868-A8 only)
+// ============================================================
+// Runs every 60 seconds. Checks pump states and adjusts
+// simulated pH/ORP values accordingly.
+// Only active when SIMU_PH / SIMU_ORP is enabled in Config.h.
+// ============================================================
+#ifdef KC868_A8
+void AnalogSimLoop(void *pvParameters)
+{
+  while (!startTasks) ;
+  vTaskDelay(DT7);  // Scheduling offset
+
+  TickType_t period = pdMS_TO_TICKS(60000);  // 60 seconds
+  TickType_t ticktime = xTaskGetTickCount();
+  static UBaseType_t hwm = 0;
+
+  Debug.print(DBG_INFO, "[AnalogSim] Loop started (period: 60s)");
+
+  for(;;)
+  {
+    SimSensor.updateAnalogSimulation();
+    stack_mon(hwm);
+    vTaskDelayUntil(&ticktime,period);
+  }
+}
+#endif

--- a/src/SensorSimulation.cpp
+++ b/src/SensorSimulation.cpp
@@ -4,12 +4,19 @@
  * Each sensor can be independently simulated via Config.h flags.
  * Simulation values are configurable and can be changed at runtime.
  * 
- * When simulation is active, the simulated value replaces the real sensor value.
- * When simulation is not active, the real sensor value is used.
+ * Analog simulation (pH/ORP) is driven by pump states:
+ *   - Acid pump ON  -> pH decreases (acid effect)
+ *   - Acid pump OFF -> pH increases (natural drift)
+ *   - Chlorine pump ON  -> ORP increases (chlorine effect)
+ *   - Chlorine pump OFF -> ORP decreases (natural drift)
  */
 
 #include "SensorSimulation.h"
 #include "Config.h"
+
+#ifdef KC868_A8
+  #include "PoolMaster.h"  // For PhPump, ChlPump extern declarations
+#endif
 
 // Global instance
 SensorSimulation SimSensor;
@@ -67,6 +74,52 @@ void SensorSimulation::loop() {
     
     // Optional: Add dynamic simulation behavior here
     // For example, slowly ramp values or add noise
+}
+
+// ============================================================
+// Analog Simulation Update - Called every 60s by AnalogSimLoop
+// ============================================================
+// Checks pump states and adjusts pH/ORP values accordingly:
+//   - Acid pump ON  -> pH decreases (acid effect)
+//   - Acid pump OFF -> pH increases (natural drift)
+//   - Chlorine pump ON  -> ORP increases (chlorine effect)
+//   - Chlorine pump OFF -> ORP decreases (natural drift)
+// Values are clamped to SIM_PH_MIN/MAX and SIM_ORP_MIN/MAX.
+// ============================================================
+void SensorSimulation::updateAnalogSimulation() {
+#ifdef KC868_A8
+    // --- pH Simulation ---
+    if (simulating_ph) {
+        if (PhPump.IsRunning()) {
+            // Acid pump active: pH decreases
+            sim_ph_value -= SIM_PH_ACTIVE_RATE;
+            Debug.print(DBG_INFO, "[Sim] pH decreasing (pump ON): %.3f", sim_ph_value);
+        } else {
+            // Acid pump off: pH drifts up naturally
+            sim_ph_value += SIM_PH_DRIFT_RATE;
+            Debug.print(DBG_VERBOSE, "[Sim] pH drifting up (pump OFF): %.3f", sim_ph_value);
+        }
+        // Clamp to configured bounds
+        if (sim_ph_value < SIM_PH_MIN) sim_ph_value = SIM_PH_MIN;
+        if (sim_ph_value > SIM_PH_MAX) sim_ph_value = SIM_PH_MAX;
+    }
+
+    // --- ORP Simulation ---
+    if (simulating_orp) {
+        if (ChlPump.IsRunning()) {
+            // Chlorine pump active: ORP increases
+            sim_orp_value += SIM_ORP_ACTIVE_RATE;
+            Debug.print(DBG_INFO, "[Sim] ORP increasing (pump ON): %.1f", sim_orp_value);
+        } else {
+            // Chlorine pump off: ORP drifts down naturally
+            sim_orp_value -= SIM_ORP_DRIFT_RATE;
+            Debug.print(DBG_VERBOSE, "[Sim] ORP drifting down (pump OFF): %.1f", sim_orp_value);
+        }
+        // Clamp to configured bounds
+        if (sim_orp_value < SIM_ORP_MIN) sim_orp_value = SIM_ORP_MIN;
+        if (sim_orp_value > SIM_ORP_MAX) sim_orp_value = SIM_ORP_MAX;
+    }
+#endif
 }
 
 int8_t SensorSimulation::getSimulatedInput(uint8_t pin) {

--- a/src/SensorSimulation.cpp
+++ b/src/SensorSimulation.cpp
@@ -88,34 +88,41 @@ void SensorSimulation::loop() {
 // ============================================================
 void SensorSimulation::updateAnalogSimulation() {
 #ifdef KC868_A8
+    bool phPumpOn = PhPump.IsRunning();
+    bool chlPumpOn = ChlPump.IsRunning();
+
+    Debug.print(DBG_INFO, "[AnalogSim] PhPump: %s | ChlPump: %s",
+        phPumpOn ? "ON" : "OFF",
+        chlPumpOn ? "ON" : "OFF");
+
     // --- pH Simulation ---
     if (simulating_ph) {
-        if (PhPump.IsRunning()) {
-            // Acid pump active: pH decreases
+        double oldPH = sim_ph_value;
+        if (phPumpOn) {
             sim_ph_value -= SIM_PH_ACTIVE_RATE;
-            Debug.print(DBG_INFO, "[Sim] pH decreasing (pump ON): %.3f", sim_ph_value);
+            Debug.print(DBG_INFO, "[Sim] pH: %.3f -> %.3f (pump ON, -%.3f)",
+                oldPH, sim_ph_value, SIM_PH_ACTIVE_RATE);
         } else {
-            // Acid pump off: pH drifts up naturally
             sim_ph_value += SIM_PH_DRIFT_RATE;
-            Debug.print(DBG_VERBOSE, "[Sim] pH drifting up (pump OFF): %.3f", sim_ph_value);
+            Debug.print(DBG_INFO, "[Sim] pH: %.3f -> %.3f (pump OFF, +%.3f)",
+                oldPH, sim_ph_value, SIM_PH_DRIFT_RATE);
         }
-        // Clamp to configured bounds
         if (sim_ph_value < SIM_PH_MIN) sim_ph_value = SIM_PH_MIN;
         if (sim_ph_value > SIM_PH_MAX) sim_ph_value = SIM_PH_MAX;
     }
 
     // --- ORP Simulation ---
     if (simulating_orp) {
-        if (ChlPump.IsRunning()) {
-            // Chlorine pump active: ORP increases
+        double oldORP = sim_orp_value;
+        if (chlPumpOn) {
             sim_orp_value += SIM_ORP_ACTIVE_RATE;
-            Debug.print(DBG_INFO, "[Sim] ORP increasing (pump ON): %.1f", sim_orp_value);
+            Debug.print(DBG_INFO, "[Sim] ORP: %.1f -> %.1f (pump ON, +%.1f)",
+                oldORP, sim_orp_value, SIM_ORP_ACTIVE_RATE);
         } else {
-            // Chlorine pump off: ORP drifts down naturally
             sim_orp_value -= SIM_ORP_DRIFT_RATE;
-            Debug.print(DBG_VERBOSE, "[Sim] ORP drifting down (pump OFF): %.1f", sim_orp_value);
+            Debug.print(DBG_INFO, "[Sim] ORP: %.1f -> %.1f (pump OFF, -%.1f)",
+                oldORP, sim_orp_value, SIM_ORP_DRIFT_RATE);
         }
-        // Clamp to configured bounds
         if (sim_orp_value < SIM_ORP_MIN) sim_orp_value = SIM_ORP_MIN;
         if (sim_orp_value > SIM_ORP_MAX) sim_orp_value = SIM_ORP_MAX;
     }

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -154,6 +154,10 @@ void ProcessCommand(void*);
 void SettingsPublish(void*);
 void MeasuresPublish(void*);
 void StatusLights(void*);
+
+#ifdef KC868_A8
+void AnalogSimLoop(void*);
+#endif
 void UpdateTFT(void*);
 void HistoryStats(void *);
 
@@ -488,7 +492,20 @@ void setup()
     1,
     nullptr,
     app_cpu
-  );  
+  );
+
+#ifdef KC868_A8
+  // Analog sensor simulation loop (pH/ORP dynamic simulation)
+  xTaskCreatePinnedToCore(
+    AnalogSimLoop,
+    "AnalogSimLoop",
+    2048,
+    NULL,
+    1,
+    nullptr,
+    app_cpu
+  );
+#endif
 
   // Measures MQTT publish 
   xTaskCreatePinnedToCore(


### PR DESCRIPTION
## Problem

Die bisherige Analog-Simulation (pH/ORP) lieferte nur statische Werte — kein realistisches Verhalten bei laufender Pumpe.

## Lösung

Neuer autonomer **60-Sekunden-Loop** (`AnalogSimLoop`) als FreeRTOS-Task, der die simulierten pH/ORP-Werte basierend auf dem tatsächlichen Pumpenzustand anpasst:

| Pumpe | Sensor | Richtung |
|-------|--------|----------|
| Säurepumpe **AN** | pH | **sinkt** (Säure wirkt) |
| Säurepumpe **AUS** | pH | **steigt** natürlich (Puffer) |
| Chlorpumpe **AN** | ORP | **steigt** (Chlor wirkt) |
| Chlorpumpe **AUS** | ORP | **sinkt** natürlich (Abbau) |

Werte werden an konfigurierbare Min/Max-Grenzen geclampt.

## Config.h Ergänzungen

```cpp
// pH Simulation
#define SIM_PH_ACTIVE_RATE    0.02   // Sinken/Min bei laufender Säurepumpe
#define SIM_PH_DRIFT_RATE     0.005  // Anstieg/Min bei stehender Pumpe
#define SIM_PH_MIN            6.0    // Minimum
#define SIM_PH_MAX            8.5    // Maximum

// ORP Simulation
#define SIM_ORP_ACTIVE_RATE   5.0    // Anstieg/Min bei laufender Chlorpumpe
#define SIM_ORP_DRIFT_RATE    2.0    // Sinken/Min bei stehender Pumpe
#define SIM_ORP_MIN           400.0  // Minimum
#define SIM_ORP_MAX           900.0  // Maximum
```

## Änderungen

- **Config.h**: Neue Konstanten für simulierte Raten und Grenzen
- **SensorSimulation.h/cpp**: Neue `updateAnalogSimulation()` Methode
- **Loops.cpp**: Neuer `AnalogSimLoop` FreeRTOS-Task (nur KC868-A8)
- **Setup.cpp**: Task registriert + Forward-Deklaration