### PR TITLE
Add debug output for pump start/stop with runtime tracking

### DIFF
--- a/lib/Pump-master/src/Pin.cpp
+++ b/lib/Pump-master/src/Pin.cpp
@@ -17,14 +17,7 @@ void PIN::Initialize(uint8_t _pin_number, uint8_t _pin_direction, bool _active_l
   // Set variables
   if((_pin_number != pin_number) && (_pin_direction != INPUT_DIGITAL) && ((pin_direction==OUTPUT_DIGITAL)||(pin_direction==OUTPUT_PWM))) { // If we changed port
     if(_pin_number != 0) {
-#ifdef KC868_A8
-      // KC868: virtual pins (100+) — managed by I/O layer, skip raw GPIO
-      if (pin_number < 100) {
-#endif
       digitalWrite(pin_number,!active_level); // Inactivate the previous port
-#ifdef KC868_A8
-      }
-#endif
       // IMPORTANT NOTE: Always change pin number in following order
       //  ->SetPinNumber
       //  ->SetActiveLevel
@@ -43,14 +36,7 @@ void PIN::Begin()
   //("Call Begin %d (%d)\r\n",pin_number,pin_direction);
   if(pin_number!=0) {
     // Open the port for OUTPUT and set it to down state
-    if(pin_direction==OUTPUT_DIGITAL) {
-#ifdef KC868_A8
-      // KC868: virtual pins (100+) are managed by the I/O layer via setRelay()
-      // Skip raw pinMode/digitalWrite — they hit unconnected GPIOs, not the I2C expander
-      if (pin_number >= 100) {
-        return;
-      }
-#endif
+    if(pin_direction==OUTPUT_DIGITAL) {  
       pinMode(pin_number, OUTPUT);
       digitalWrite(pin_number,!active_level); // Initialize the port to inactive
     } else if(pin_direction==INPUT_DIGITAL) {
@@ -62,14 +48,8 @@ void PIN::Begin()
 //Switch the PIN ON
 void PIN::Enable()
 {
-  if (pin_number != 0) {
-#ifdef KC868_A8
-    // KC868: virtual relay pins (100-107) — control via I2C expander
-    if (pin_number >= 100 && pin_number <= 107) {
-      KC868.setRelay(pin_number - 100, true);
-      return;
-    }
-#endif
+  if (pin_number != 0)
+  {
     digitalWrite(pin_number, active_level);
   }
 }
@@ -77,14 +57,8 @@ void PIN::Enable()
 //Switch the PIN OFF
 void PIN::Disable()
 {
-  if (pin_number != 0) {
-#ifdef KC868_A8
-    // KC868: virtual relay pins (100-107) — control via I2C expander
-    if (pin_number >= 100 && pin_number <= 107) {
-      KC868.setRelay(pin_number - 100, false);
-      return;
-    }
-#endif
+  if (pin_number != 0)
+  {
     digitalWrite(pin_number, !active_level);
   }
 }
@@ -137,15 +111,11 @@ bool PIN::IsActive()
 {
   if (pin_number != 0) {
 #ifdef KC868_A8
-    // KC868: virtual relay pins (100-107) — read from KC868 I/O layer, not raw GPIO
-    // Raw GPIO is unconnected to the I2C expander; KC868.digitalRead() returns 0
-    // when not initialized, causing IsActive() to always return true for ACTIVE_LOW
-    if (pin_number >= 100 && pin_number <= 107) {
-      return KC868.getRelay(pin_number - 100);
-    }
-    // KC868: virtual input pins (110-117) — read via KC868 I/O layer
-    if (pin_number >= 110 && pin_number <= 117) {
-      return KC868.getInput(pin_number - 110);
+    // Check simulation first: if simulation is active for this pin,
+    // use the simulated value instead of reading the physical pin.
+    int8_t simVal = SimSensor.getSimulatedInput(pin_number);
+    if (simVal >= 0) {
+        return (simVal == HIGH);  // Simulated value: HIGH = active
     }
 #endif
     return (digitalRead(pin_number) == active_level);

--- a/lib/Pump-master/src/Pin.cpp
+++ b/lib/Pump-master/src/Pin.cpp
@@ -17,7 +17,14 @@ void PIN::Initialize(uint8_t _pin_number, uint8_t _pin_direction, bool _active_l
   // Set variables
   if((_pin_number != pin_number) && (_pin_direction != INPUT_DIGITAL) && ((pin_direction==OUTPUT_DIGITAL)||(pin_direction==OUTPUT_PWM))) { // If we changed port
     if(_pin_number != 0) {
+#ifdef KC868_A8
+      // KC868: virtual pins (100+) — managed by I/O layer, skip raw GPIO
+      if (pin_number < 100) {
+#endif
       digitalWrite(pin_number,!active_level); // Inactivate the previous port
+#ifdef KC868_A8
+      }
+#endif
       // IMPORTANT NOTE: Always change pin number in following order
       //  ->SetPinNumber
       //  ->SetActiveLevel
@@ -36,7 +43,14 @@ void PIN::Begin()
   //("Call Begin %d (%d)\r\n",pin_number,pin_direction);
   if(pin_number!=0) {
     // Open the port for OUTPUT and set it to down state
-    if(pin_direction==OUTPUT_DIGITAL) {  
+    if(pin_direction==OUTPUT_DIGITAL) {
+#ifdef KC868_A8
+      // KC868: virtual pins (100+) are managed by the I/O layer via setRelay()
+      // Skip raw pinMode/digitalWrite — they hit unconnected GPIOs, not the I2C expander
+      if (pin_number >= 100) {
+        return;
+      }
+#endif
       pinMode(pin_number, OUTPUT);
       digitalWrite(pin_number,!active_level); // Initialize the port to inactive
     } else if(pin_direction==INPUT_DIGITAL) {
@@ -111,11 +125,15 @@ bool PIN::IsActive()
 {
   if (pin_number != 0) {
 #ifdef KC868_A8
-    // Check simulation first: if simulation is active for this pin,
-    // use the simulated value instead of reading the physical pin.
-    int8_t simVal = SimSensor.getSimulatedInput(pin_number);
-    if (simVal >= 0) {
-        return (simVal == HIGH);  // Simulated value: HIGH = active
+    // KC868: virtual relay pins (100-107) — read from KC868 I/O layer, not raw GPIO
+    // Raw GPIO is unconnected to the I2C expander; KC868.digitalRead() returns 0
+    // when not initialized, causing IsActive() to always return true for ACTIVE_LOW
+    if (pin_number >= 100 && pin_number <= 107) {
+      return KC868.getRelay(pin_number - 100);
+    }
+    // KC868: virtual input pins (110-117) — read via KC868 I/O layer
+    if (pin_number >= 110 && pin_number <= 117) {
+      return KC868.getInput(pin_number - 110);
     }
 #endif
     return (digitalRead(pin_number) == active_level);

--- a/lib/Pump-master/src/Pin.cpp
+++ b/lib/Pump-master/src/Pin.cpp
@@ -62,8 +62,14 @@ void PIN::Begin()
 //Switch the PIN ON
 void PIN::Enable()
 {
-  if (pin_number != 0)
-  {
+  if (pin_number != 0) {
+#ifdef KC868_A8
+    // KC868: virtual relay pins (100-107) — control via I2C expander
+    if (pin_number >= 100 && pin_number <= 107) {
+      KC868.setRelay(pin_number - 100, true);
+      return;
+    }
+#endif
     digitalWrite(pin_number, active_level);
   }
 }
@@ -71,8 +77,14 @@ void PIN::Enable()
 //Switch the PIN OFF
 void PIN::Disable()
 {
-  if (pin_number != 0)
-  {
+  if (pin_number != 0) {
+#ifdef KC868_A8
+    // KC868: virtual relay pins (100-107) — control via I2C expander
+    if (pin_number >= 100 && pin_number <= 107) {
+      KC868.setRelay(pin_number - 100, false);
+      return;
+    }
+#endif
     digitalWrite(pin_number, !active_level);
   }
 }

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -80,7 +80,8 @@ u_int8_t Pump::Start(bool _resetUpTime)
     } else {
       LastLoopMillis = StartTime = millis(); 
 #ifdef KC868_A8
-      Serial.printf("[Pump::Start] pin=%d Pump STARTED OK\r\n", GetPinNumber());
+      Serial.printf("[Pump::Start] '%s' pin=%d STARTED at %lu ms, UpTime=%.1fs\r\n",
+        GetName(), GetPinNumber(), millis(), GetUpTime());
 #endif
     }
   }
@@ -92,13 +93,21 @@ bool Pump::Stop()
 {
   if(IsRunning())
   {
+    unsigned long delta = millis() - LastLoopMillis;
     if (!this->Relay::Disable())
     {
+#ifdef KC868_A8
+      Serial.printf("[Pump::Stop]  '%s' pin=%d Relay Disable FAILED!\r\n",
+        GetName(), GetPinNumber());
+#endif
       return false;
     }
     
-    UpTime += millis() - LastLoopMillis; 
-
+    UpTime += delta;
+#ifdef KC868_A8
+    Serial.printf("[Pump::Stop]  '%s' pin=%d STOPPED  at %lu ms, delta=%lu ms, UpTime=%.1fs\r\n",
+      GetName(), GetPinNumber(), millis(), delta, GetUpTime());
+#endif
     
     return true;
   } else return false;

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -41,7 +41,7 @@ bool MDNSStatus = false;
 bool AntiFreezeFiltering = false;               // Filtration anti freeze mode
 //bool EmergencyStopFiltPump = false;             // flag will be (re)set by double-tapp button
 bool PSIError = false;                          // Water pressure OK
-bool cleaning_done = false;                     // daily cleaning done   
+cleaning_done = false;                     // daily cleaning done   
 
 // NTP & MQTT Connected
 bool PoolMaster_BoardReady = false;      // Is Board Up
@@ -57,9 +57,9 @@ QueueHandle_t queueIn;
 // NVS Non Volatile SRAM (eqv. EEPROM)
 Preferences nvs;      
 
-// Instanciations of Pump and PID objects to make them global. But the constructors are then called 
+// Instanciations of Pump and PID objects to make them global. But the constructors are then called
 // before loading of the storage struct. At run time, the attributes take the default
-// values of the storage struct as they are compiled, just a few lines above, and not those which will 
+// values of the storage struct as they are compiled, just a few lines above, and not those which will
 // be read from NVS later. This means that the correct objects attributes must be set later in
 // the setup function (fortunatelly, init methods exist).
 
@@ -75,7 +75,6 @@ Preferences nvs;
 //    5/ Tankvolume is used to compute the percentage of tank used/remaining
 // IMPORTANT NOTE: second argument is ID and MUST correspond to the equipment index in the "Pool_Equipment" vector
 // FiltrationPump: This Pump controls the filtration, no tank attached and not interlocked to any element. SSD relay attached works with HIGH level.
-
 Pump FiltrationPump(FILTRATION);
 // pHPump: This Pump has no low-level switch so remaining volume is estimated. It is interlocked with the relay of the FilrationPump
 //Pump PhPump(PH_PUMP, PH_LEVEL, ACTIVE_LOW, MODE_LATCHING, storage.pHPumpFR, storage.pHTankVol, storage.AcidFill);
@@ -86,7 +85,7 @@ Pump ChlPump(CHL_PUMP,CHL_LEVEL);
 // RobotPump: This Pump is not injecting liquid so tank is associated to it. It is interlocked with the relay of the FilrationPump
 Pump RobotPump(ROBOT);
 // SWG: This Pump is associated with a Salt Water Chlorine Generator. It turns on and off the equipment to produce chlorine.
-// It has no tank associated. It is interlocked with the relay of the FilrationPump
+// It has no tank associated. It is interlocked with the relay of the FiltrationPump
 Pump SWGPump(SWG_PUMP);
 // Filling Pump: This pump is autonomous, not interlocked with filtering pump.
 Pump FillingPump(FILL_PUMP);
@@ -113,7 +112,7 @@ PID OrpPID(&PMData.OrpValue, &PMData.OrpPIDOutput, &PMData.Orp_SetPoint, 0, 0, 0
 static TaskHandle_t pubSetTaskHandle;
 static TaskHandle_t pubMeasTaskHandle;
 
-// Used for ElegantOTA
+// For ElegantOTA
 //unsigned long ota_progress_millis = 0;
 
 // Configuration Manager
@@ -164,7 +163,7 @@ void HistoryStats(void *);
 // For ElegantOTA
 /*void onOTAStart(void);
 void onOTAProgress(size_t,size_t);
-void onOTAEnd(bool);*/
+void onOTAEnd(void);*/
 
 // Setup
 void setup()
@@ -283,14 +282,11 @@ void setup()
   PMConfig.printAllParams(); // Print all parameters to Serial for debug
 
 #ifdef KC868_A8
-  // Initialize KC868-A8 I/O layer (PCF8574 expanders)
-  KC868.begin();
-  
-  // Initialize sensor simulation system
+  // Initialize sensor simulation system (before KC868 I/O layer)
   SimSensor.begin();
 #endif
 
-  //Define pins directions
+  // Define pins directions
 #if BUZZER != 255
   pinMode(BUZZER, OUTPUT);
 #endif
@@ -316,7 +312,7 @@ void setup()
   ChlPump.SetInterlock(DEVICE_FILTPUMP); // Chlorine Pump interlocked with Filtration Pump
   RobotPump.SetInterlock(DEVICE_FILTPUMP); // Robot Pump interlocked with Filtration Pump
   SWGPump.SetInterlock(DEVICE_FILTPUMP); // SWG Pump interlocked
-  
+
   // Default values for the pumps
   FillingPump.SetMinUpTime(5*60*1000);  // Minimum running uptime for Filling Pump is 5 minutes (avoir short runs)
   FiltrationPump.SetMaxUpTime(0); // No Maximum uptime for Filtration Pump
@@ -342,7 +338,6 @@ void setup()
   // Load configuration parameters from NVS for all devices
   PoolDeviceManager.LoadPreferences();
   PoolDeviceManager.InitDevicesInterlock();
-  PoolDeviceManager.Begin();
 
   // Initialize watch-dog
   esp_task_wdt_init(WDT_TIMEOUT, true);
@@ -362,7 +357,7 @@ void setup()
     delay(500);
     Serial.print(".");
   }
-  
+
   // Start I2C for ADS1115 and status lights through PCF8574A
   Wire.begin(I2C_SDA,I2C_SCL);
 
@@ -378,13 +373,20 @@ void setup()
   Wire.endTransmission();
 
 #ifdef KC868_A8
-  // Wire is now initialized — explicitly turn all relays OFF.
-  // KC868.begin() ran before Wire.begin() so its I2C write never reached hardware.
+  // Initialize KC868-A8 I/O layer AFTER Wire.begin() — I2C must be ready
+  // so that the relay OFF command actually reaches the PCF8574 hardware.
+  KC868.begin();
+
+  // Explicitly turn all relays OFF.
   for (uint8_t i = 0; i < 8; i++) {
-    KC868.setRelay(i, true);
+    KC868.setRelay(i, false);
   }
   Debug.print(DBG_INFO,"[KC868-A8] All relays set to OFF (boot reset)");
 #endif
+
+  // Now initialize devices — Begin() writes to KC868 I/O layer which
+  // is ready (initialized=true) since KC868.begin() ran above.
+  PoolDeviceManager.Begin();
 
   // Initialize PIDs
   PMData.PhPIDwStart  = millis();
@@ -460,7 +462,7 @@ void setup()
     nullptr,
     app_cpu
   );
-  
+
  // ORP regulation loop
     xTaskCreatePinnedToCore(
     OrpRegulation,
@@ -484,7 +486,7 @@ void setup()
   );
 
   // Status lights display
-  xTaskCreatePinnedToCore(
+    xTaskCreatePinnedToCore(
     StatusLights,
     "StatusLights",
     2048,
@@ -575,7 +577,7 @@ void setup()
   ArduinoOTA.setPort(OTA_PORT);
   ArduinoOTA.setHostname("PoolMaster");
   ArduinoOTA.setPasswordHash(OTA_PWDHASH);
-  
+
   ArduinoOTA.onStart([]() {
     String type;
     if (ArduinoOTA.getCommand() == U_FLASH)
@@ -700,4 +702,3 @@ void loop()
   delay(1000);
   vTaskDelete(nullptr);
 }
-

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -41,7 +41,7 @@ bool MDNSStatus = false;
 bool AntiFreezeFiltering = false;               // Filtration anti freeze mode
 //bool EmergencyStopFiltPump = false;             // flag will be (re)set by double-tapp button
 bool PSIError = false;                          // Water pressure OK
-cleaning_done = false;                     // daily cleaning done   
+bool cleaning_done = false;                     // daily cleaning done   
 
 // NTP & MQTT Connected
 bool PoolMaster_BoardReady = false;      // Is Board Up

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -57,9 +57,9 @@ QueueHandle_t queueIn;
 // NVS Non Volatile SRAM (eqv. EEPROM)
 Preferences nvs;      
 
-// Instanciations of Pump and PID objects to make them global. But the constructors are then called
+// Instanciations of Pump and PID objects to make them global. But the constructors are then called 
 // before loading of the storage struct. At run time, the attributes take the default
-// values of the storage struct as they are compiled, just a few lines above, and not those which will
+// values of the storage struct as they are compiled, just a few lines above, and not those which will 
 // be read from NVS later. This means that the correct objects attributes must be set later in
 // the setup function (fortunatelly, init methods exist).
 
@@ -112,7 +112,7 @@ PID OrpPID(&PMData.OrpValue, &PMData.OrpPIDOutput, &PMData.Orp_SetPoint, 0, 0, 0
 static TaskHandle_t pubSetTaskHandle;
 static TaskHandle_t pubMeasTaskHandle;
 
-// For ElegantOTA
+// Used for ElegantOTA
 //unsigned long ota_progress_millis = 0;
 
 // Configuration Manager
@@ -163,7 +163,7 @@ void HistoryStats(void *);
 // For ElegantOTA
 /*void onOTAStart(void);
 void onOTAProgress(size_t,size_t);
-void onOTAEnd(void);*/
+void onOTAEnd(bool);*/
 
 // Setup
 void setup()
@@ -282,11 +282,14 @@ void setup()
   PMConfig.printAllParams(); // Print all parameters to Serial for debug
 
 #ifdef KC868_A8
-  // Initialize sensor simulation system (before KC868 I/O layer)
+  // Initialize KC868-A8 I/O layer (PCF8574 expanders)
+  KC868.begin();
+  
+  // Initialize sensor simulation system
   SimSensor.begin();
 #endif
 
-  // Define pins directions
+  //Define pins directions
 #if BUZZER != 255
   pinMode(BUZZER, OUTPUT);
 #endif
@@ -312,7 +315,7 @@ void setup()
   ChlPump.SetInterlock(DEVICE_FILTPUMP); // Chlorine Pump interlocked with Filtration Pump
   RobotPump.SetInterlock(DEVICE_FILTPUMP); // Robot Pump interlocked with Filtration Pump
   SWGPump.SetInterlock(DEVICE_FILTPUMP); // SWG Pump interlocked
-
+  
   // Default values for the pumps
   FillingPump.SetMinUpTime(5*60*1000);  // Minimum running uptime for Filling Pump is 5 minutes (avoir short runs)
   FiltrationPump.SetMaxUpTime(0); // No Maximum uptime for Filtration Pump
@@ -338,6 +341,7 @@ void setup()
   // Load configuration parameters from NVS for all devices
   PoolDeviceManager.LoadPreferences();
   PoolDeviceManager.InitDevicesInterlock();
+  PoolDeviceManager.Begin();
 
   // Initialize watch-dog
   esp_task_wdt_init(WDT_TIMEOUT, true);
@@ -357,7 +361,7 @@ void setup()
     delay(500);
     Serial.print(".");
   }
-
+  
   // Start I2C for ADS1115 and status lights through PCF8574A
   Wire.begin(I2C_SDA,I2C_SCL);
 
@@ -373,20 +377,13 @@ void setup()
   Wire.endTransmission();
 
 #ifdef KC868_A8
-  // Initialize KC868-A8 I/O layer AFTER Wire.begin() — I2C must be ready
-  // so that the relay OFF command actually reaches the PCF8574 hardware.
-  KC868.begin();
-
-  // Explicitly turn all relays OFF.
+  // Wire is now initialized — explicitly turn all relays OFF.
+  // KC868.begin() ran before Wire.begin() so its I2C write never reached hardware.
   for (uint8_t i = 0; i < 8; i++) {
-    KC868.setRelay(i, false);
+    KC868.setRelay(i, true);
   }
   Debug.print(DBG_INFO,"[KC868-A8] All relays set to OFF (boot reset)");
 #endif
-
-  // Now initialize devices — Begin() writes to KC868 I/O layer which
-  // is ready (initialized=true) since KC868.begin() ran above.
-  PoolDeviceManager.Begin();
 
   // Initialize PIDs
   PMData.PhPIDwStart  = millis();
@@ -462,7 +459,7 @@ void setup()
     nullptr,
     app_cpu
   );
-
+  
  // ORP regulation loop
     xTaskCreatePinnedToCore(
     OrpRegulation,
@@ -486,7 +483,7 @@ void setup()
   );
 
   // Status lights display
-    xTaskCreatePinnedToCore(
+  xTaskCreatePinnedToCore(
     StatusLights,
     "StatusLights",
     2048,
@@ -577,7 +574,7 @@ void setup()
   ArduinoOTA.setPort(OTA_PORT);
   ArduinoOTA.setHostname("PoolMaster");
   ArduinoOTA.setPasswordHash(OTA_PWDHASH);
-
+  
   ArduinoOTA.onStart([]() {
     String type;
     if (ArduinoOTA.getCommand() == U_FLASH)


### PR DESCRIPTION
## Ziel
Debug-Ausgaben hinzufügen, um die Laufzeit der Pumpe beim Start und Stopp zu verfolgen. Hilft beim Debuggen von UpTime-Diskrepanzen (z.B. 747s gemeldet vs. 271s tatsächlich).

## Änderungen

### `Pump::Start()`
- Zeigt Pumpenname, Pin-Nummer, `millis()` und aktuellen UpTime-Wert

### `Pump::Stop()`
- Berechnet `delta` **vor** `Relay::Disable()` (nicht danach)
- Zeigt Pumpenname, Pin-Nummer, `millis()`, delta, und resultierenden UpTime
- Bei `Relay::Disable()`-Fehler: Debug-Ausgabe

### Beispiel-Ausgabe
```
[Pump::Start] 'Chlorine Pump' pin=104 STARTED at 12345678 ms, UpTime=0.0s
[Pump::Stop]  'Chlorine Pump' pin=104 STOPPED  at 12351678 ms, delta=60000 ms, UpTime=60.0s
```

Alle Ausgaben sind durch `#ifdef KC868_A8` abgeschirmt — kein Overhead auf anderen Plattformen.