### PR TITLE
Fix: UpTime double-counting race condition between PID task and main loop

### DIFF
--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -32,8 +32,12 @@ void Pump::loop()
   {
     if (loopHandler) loopHandler(); // Appel du handler à chaque boucle
 
-    UpTime += millis() - LastLoopMillis;
-    LastLoopMillis = millis();
+    // Guard: if Stop() was called from another task (e.g. PID regulation),
+    // skip accumulation here to prevent double-counting UpTime.
+    if (!_stopped) {
+      UpTime += millis() - LastLoopMillis;
+      LastLoopMillis = millis();
+    }
 
     if((CurrMaxUpTime > 0) && (UpTime >= CurrMaxUpTime))
     {
@@ -78,9 +82,11 @@ u_int8_t Pump::Start(bool _resetUpTime)
 #endif
       return bitMaskErrors;
     } else {
+      _stopped = false; // Clear guard so Pump::loop() resumes accumulation
       LastLoopMillis = StartTime = millis(); 
 #ifdef KC868_A8
-      Serial.printf("[Pump::Start] pin=%d Pump STARTED OK\r\n", GetPinNumber());
+      Serial.printf("[Pump::Start] '%s' pin=%d STARTED at %lu ms, UpTime=%.1fs\r\n",
+        GetName(), GetPinNumber(), millis(), GetUpTime());
 #endif
     }
   }
@@ -92,13 +98,23 @@ bool Pump::Stop()
 {
   if(IsRunning())
   {
+    _stopped = true; // Set guard BEFORE disabling relay to prevent Pump::loop() double-count
+    unsigned long delta = millis() - LastLoopMillis;
     if (!this->Relay::Disable())
     {
+#ifdef KC868_A8
+      Serial.printf("[Pump::Stop]  '%s' pin=%d Relay Disable FAILED!\r\n",
+        GetName(), GetPinNumber());
+#endif
+      _stopped = false; // Reset guard on failure
       return false;
     }
     
-    UpTime += millis() - LastLoopMillis; 
-
+    UpTime += delta;
+#ifdef KC868_A8
+    Serial.printf("[Pump::Stop]  '%s' pin=%d STOPPED  at %lu ms, delta=%lu ms, UpTime=%.1fs\r\n",
+      GetName(), GetPinNumber(), millis(), delta, GetUpTime());
+#endif
     
     return true;
   } else return false;
@@ -199,6 +215,7 @@ void Pump::ResetUpTime()
   StartTime = 0;
   StopTime = 0;
   UpTime = 0;
+  _stopped = false; // Clear guard on reset
   CurrMaxUpTime = MaxUpTime;
   LastLoopMillis = millis();  // FIX: preserve millis() reference to avoid jump in UpTime calculation
 }

--- a/lib/Pump-master/src/Pump.h
+++ b/lib/Pump-master/src/Pump.h
@@ -99,6 +99,7 @@ class Pump : public Relay {
     PIN*  interlock_pump_     = nullptr; // Interlock can be passed 
     uint8_t interlock_pin_id  = NO_INTERLOCK; // Used temporarily to store the interlock pin id but converted in pointer by InitInterlock function
     unsigned long LastLoopMillis     = 0;
+    bool          _stopped     = false; // Guard: prevents double-counting when Stop() is called from PID task
     uint8_t tank_level_pin;
     double flowrate, tankvolume, tankfill; // Flowrate in L/h, tank volume in Liters, tank fill in %
 };


### PR DESCRIPTION
## Problem
ChlPump reported 747s uptime but actual runtime was only 271s (~2.75× too high).

Debug-Ausgaben (PR #15) zeigten: Zwischen Stop und dem nächsten Start stieg UpTime massiv an, obwohl die Pumpe ausgeschaltet war.

## Root Cause
Race Condition zwischen PID-Task (`OrpRegulation`) und Hauptloop (`Pump::loop()`):

1. PID-Task ruft `ChlPump.Stop()` auf → Relay deaktiviert, `UpTime += delta`
2. Gleichzeitig hat `Pump::loop()` den `IsRunning()`-Check schon passiert → akkumuliert ebenfalls `UpTime += millis() - LastLoopMillis`
3. **Resultat: Doppelte Zeitberechnung pro Zyklus**

## Fix
`_stopped` Guard-Flag (Pump.h):

| Aktion | Wirkung |
|--------|---------|
| `Stop()` setzt `_stopped = true` | **Vor** `Relay::Disable()` → verhindert dass `Pump::loop()` noch akkumuliert |
| `Stop()` berechnet `delta` | **Vor** `Relay::Disable()` → exakter letzter Delta |
| `Stop()` addiert `UpTime += delta` | **Nach** erfolgreichem `Disable()` |
| `Start()` setzt `_stopped = false` | Normalbetrieb wird wieder aufgenommen |
| `ResetUpTime()` setzt `_stopped = false` | Sauberer Zustand bei Tagesreset |

## Änderungen
- **Pump.h**: `bool _stopped = false` (private Member)
- **Pump.cpp**: `Stop()` — Guard vor Disable, Delta-Berechnung vor Disable
- **Pump.cpp**: `loop()` — Prüft `!_stopped` vor Akkumulation
- **Pump.cpp**: `Start()` — Setzt `_stopped = false` nach Enable
- **Pump.cpp**: `ResetUpTime()` — Setzt `_stopped = false`
- Debug-Ausgaben (Name, Pin, millis(), delta, UpTime) unter `#ifdef KC868_A8`

## Erwartetes Ergebnis
Nach dem Fix sollte die Debug-Ausgabe zeigen:
```
[Pump::Start] 'Chlorine Pump' pin=103 STARTED at 1743172 ms, UpTime=0.0s
[Pump::Stop]  'Chlorine Pump' pin=103 STOPPED  at 1795228 ms, delta=52056 ms, UpTime=52.1s
[Pump::Start] 'Chlorine Pump' pin=103 STARTED at 1801236 ms, UpTime=52.1s  ← kein Sprung!
```