### PR TITLE
fix: KC868 relay init sync — Pin::Begin() overwriting relayState

### DIFF
--- a/lib/Pump-master/src/Pin.cpp
+++ b/lib/Pump-master/src/Pin.cpp
@@ -17,7 +17,15 @@ void PIN::Initialize(uint8_t _pin_number, uint8_t _pin_direction, bool _active_l
   // Set variables
   if((_pin_number != pin_number) && (_pin_direction != INPUT_DIGITAL) && ((pin_direction==OUTPUT_DIGITAL)||(pin_direction==OUTPUT_PWM))) { // If we changed port
     if(_pin_number != 0) {
-      digitalWrite(pin_number,!active_level); // Inactivate the previous port
+#ifdef KC868_A8
+      // On KC868-A8, relay pins (100-107) are managed by the KC868 I/O layer.
+      // Skip digitalWrite to avoid overwriting relayState.
+      if(pin_number < 100 || pin_number > 107) {
+#endif
+        digitalWrite(pin_number,!active_level); // Inactivate the previous port
+#ifdef KC868_A8
+      }
+#endif
       // IMPORTANT NOTE: Always change pin number in following order
       //  ->SetPinNumber
       //  ->SetActiveLevel
@@ -33,8 +41,14 @@ void PIN::Initialize(uint8_t _pin_number, uint8_t _pin_direction, bool _active_l
 //Open the port
 void PIN::Begin()
 {
-  //("Call Begin %d (%d)\r\n",pin_number,pin_direction);
   if(pin_number!=0) {
+#ifdef KC868_A8
+    // On KC868-A8, relay pins (100-107) are managed by the KC868 I/O layer
+    // (via setRelay()). Skip pinMode/digitalWrite to avoid overwriting relayState.
+    if(pin_direction==OUTPUT_DIGITAL && pin_number >= 100 && pin_number <= 107) {
+      return; // Relay pin — already initialized by KC868.setRelay()
+    }
+#endif
     // Open the port for OUTPUT and set it to down state
     if(pin_direction==OUTPUT_DIGITAL) {  
       pinMode(pin_number, OUTPUT);

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -73,14 +73,15 @@ u_int8_t Pump::Start(bool _resetUpTime)
     if (!this->Relay::Enable()) {
       bitMaskErrors |= (1 << 3); // Bit 3: Relay error
 #ifdef KC868_A8
-      Serial.printf("[Pump::Start] pin=%d Relay Enable FAILED! bits=0x%02X\r\n",
-        GetPinNumber(), bitMaskErrors);
+      Serial.printf("[Pump::Start] '%s' pin=%d Relay Enable FAILED! bits=0x%02X\r\n",
+        GetName(), GetPinNumber(), bitMaskErrors);
 #endif
       return bitMaskErrors;
     } else {
       LastLoopMillis = StartTime = millis(); 
 #ifdef KC868_A8
-      Serial.printf("[Pump::Start] pin=%d Pump STARTED OK\r\n", GetPinNumber());
+      Serial.printf("[Pump::Start] '%s' pin=%d STARTED at %lu ms, UpTime=%.1fs\r\n",
+        GetName(), GetPinNumber(), millis(), GetUpTime());
 #endif
     }
   }
@@ -92,13 +93,21 @@ bool Pump::Stop()
 {
   if(IsRunning())
   {
+    unsigned long delta = millis() - LastLoopMillis;
     if (!this->Relay::Disable())
     {
+#ifdef KC868_A8
+      Serial.printf("[Pump::Stop]  '%s' pin=%d Relay Disable FAILED!\r\n",
+        GetName(), GetPinNumber());
+#endif
       return false;
     }
     
-    UpTime += millis() - LastLoopMillis; 
-
+    UpTime += delta;
+#ifdef KC868_A8
+    Serial.printf("[Pump::Stop]  '%s' pin=%d STOPPED  at %lu ms, delta=%lu ms, UpTime=%.1fs\r\n",
+      GetName(), GetPinNumber(), millis(), delta, GetUpTime());
+#endif
     
     return true;
   } else return false;

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -39,7 +39,7 @@ static unsigned long ConnectionTimeout = 0; // Last action time done on TFT. Go 
 bool MDNSStatus = false;
 
 bool AntiFreezeFiltering = false;               // Filtration anti freeze mode
-//bool EmergencyStopFiltPump = false;             // flag will be (re)set by double-tapp button
+//bool EmergencyStopFiltPump = false;             // flag will be (re)set by double-tap button
 bool PSIError = false;                          // Water pressure OK
 bool cleaning_done = false;                     // daily cleaning done   
 
@@ -86,7 +86,7 @@ Pump ChlPump(CHL_PUMP,CHL_LEVEL);
 // RobotPump: This Pump is not injecting liquid so tank is associated to it. It is interlocked with the relay of the FilrationPump
 Pump RobotPump(ROBOT);
 // SWG: This Pump is associated with a Salt Water Chlorine Generator. It turns on and off the equipment to produce chlorine.
-// It has no tank associated. It is interlocked with the relay of the FilrationPump
+// It has no tank associated. It is interlocked with the relay of the FiltrationPump
 Pump SWGPump(SWG_PUMP);
 // Filling Pump: This pump is autonomous, not interlocked with filtering pump.
 Pump FillingPump(FILL_PUMP);
@@ -381,7 +381,7 @@ void setup()
   // Wire is now initialized — explicitly turn all relays OFF.
   // KC868.begin() ran before Wire.begin() so its I2C write never reached hardware.
   for (uint8_t i = 0; i < 8; i++) {
-    KC868.setRelay(i, true);
+    KC868.setRelay(i, false);
   }
   Debug.print(DBG_INFO,"[KC868-A8] All relays set to OFF (boot reset)");
 #endif


### PR DESCRIPTION
## Root Cause

After boot, `setRelay(i, true)` sets `relayState = 0xFF` for all relays. Then `DeviceManager::Begin()` calls `Pin::Begin()` for each registered device, which calls `KC868.digitalWrite(pin, !active_level)` for relay pins (100-107). This overwrites individual bits in `relayState`, causing `IsRunning()` to return incorrect values and `Pump::loop()` to accumulate `UpTime` even when pumps are physically OFF.

Additionally, `setRelay(i, true)` was turning ALL relays ON at boot despite the comment saying "OFF".

### Evidence from serial log
```
[Pump::Start] 'Filtration Pump' pin=100 STARTED at 7835 ms, UpTime=0.0s   ← correct
[Pump::Start] 'pH Pump' pin=102 STARTED at 645553 ms, UpTime=642.0s      ← WRONG! 642s accumulated while pump was OFF
```

The pH Pump's `UpTime=642.0s` at first `Start()` proves `relayState` bit 2 was set (from `setRelay(i, true)`) before `Pin::Begin()` cleared it for pin 100 but NOT for pin 102 (because `Pin::Begin()` runs before `Wire.begin()`, so its I2C writes fail silently).

## Fix

### `lib/Pump-master/src/Pin.cpp`
- **`Pin::Begin()`**: Skip `pinMode()`/`digitalWrite()` for KC868 relay pins (100-107) since they are managed by the KC868 I/O layer via `setRelay()`
- **`Pin::Initialize()`**: Same guard for pin number changes

### `src/Setup.cpp`
- Changed `KC868.setRelay(i, true)` → `KC868.setRelay(i, false)` to match the comment "All relays set to OFF"

## Impact
- Fixes pump uptime accumulation while pumps are OFF
- Ensures `IsRunning()` returns correct state for all relay-controlled pumps
- No functional change for non-KC868 platforms (guarded by `#ifdef KC868_A8`)