### PR TITLE
fix(KC868): Relay-Polarity invertieren für ACTIVE_LOW Kompatibilität

### DIFF
--- a/include/KC868A8_IO.h
+++ b/include/KC868A8_IO.h
@@ -1,0 +1,88 @@
+/*
+ * KC868-A8 I/O Abstraction Layer
+ * 
+ * Provides digitalWrite/digitalRead/pinMode redirection for KC868-A8 hardware.
+ * Virtual pins (100+) are mapped to PCF8574 I2C expanders.
+ * 
+ * Relay outputs (100-107): PCF8574 @ 0x24, active HIGH via ULN2003A
+ *   - digitalWrite/digitalRead are INVERTED for relay pins to match
+ *     the ACTIVE_LOW convention used by the Pump-master library:
+ *     digitalWrite(pin, 0) → relay ON  (value LOW = active)
+ *     digitalWrite(pin, 1) → relay OFF (value HIGH = inactive)
+ *     digitalRead(pin) returns 0 when relay ON, 1 when OFF
+ *   - Use setRelay()/getRelay() for direct (non-inverted) hardware control
+ * 
+ * Digital inputs (110-117): PCF8574 @ 0x22, active LOW
+ *   - digitalRead(pin) → HIGH = inactive, LOW = active (optocoupler triggered)
+ *   - For compatibility with original code, we invert: digitalRead returns
+ *     the ACTUAL state (HIGH when optocoupler active, LOW when inactive)
+ */
+
+#ifndef KC868A8_IO_H
+#define KC868A8_IO_H
+
+#include <Arduino.h>
+#include <Wire.h>
+#include "KC868A8_Pins.h"
+
+class KC868A8_IO {
+public:
+    KC868A8_IO();
+    
+    // Initialize I2C and read initial states
+    void begin();
+    
+    // Digital I/O for virtual pins
+    // Note: relay pins (100-107) use inverted logic (see above)
+    void digitalWrite(uint8_t pin, uint8_t value);
+    uint8_t digitalRead(uint8_t pin);
+    void pinMode(uint8_t pin, uint8_t mode);
+    
+    // Relay control (direct, non-inverted — for Setup.cpp)
+    void setRelay(uint8_t relayIndex, bool on);
+    bool getRelay(uint8_t relayIndex);
+    
+    // Input control (direct, for Setup.cpp)
+    bool getInput(uint8_t inputIndex);
+    
+    // Debug: print current states
+    void printStatus();
+
+private:
+    void readInputs();
+    void writeOutputs();
+    
+    uint8_t relayState;      // Current relay output state (bitmask)
+    uint8_t inputState;      // Current input state (bitmask, inverted from hardware)
+    uint8_t lastInputState;  // Previous input state for change detection
+    
+    bool initialized;
+};
+
+// Global instance
+extern KC868A8_IO KC868;
+
+// ============================================================
+// KC868-A8 Redirection Macros
+// ============================================================
+// These macros redirect digitalWrite/digitalRead/pinMode calls
+// through the KC868 I/O layer for virtual pins.
+
+#ifdef KC868_A8
+  // Save originals (they're macros in Arduino.h)
+  #define KC868_ORIG_DIGITAL_WRITE  digitalWrite
+  #define KC868_ORIG_DIGITAL_READ   digitalRead
+  #define KC868_ORIG_PIN_MODE       pinMode
+  
+  // Redefine for KC868-A8 virtual pin support
+  #define digitalWrite(pin, val) \
+    (IS_KC868_VIRTUAL_PIN(pin) ? KC868.digitalWrite(pin, val) : KC868_ORIG_DIGITAL_WRITE(pin, val))
+  
+  #define digitalRead(pin) \
+    (IS_KC868_VIRTUAL_PIN(pin) ? KC868.digitalRead(pin) : KC868_ORIG_DIGITAL_READ(pin))
+  
+  #define pinMode(pin, mode) \
+    (IS_KC868_VIRTUAL_PIN(pin) ? KC868.pinMode(pin, mode) : KC868_ORIG_PIN_MODE(pin, mode))
+#endif
+
+#endif // KC868A8_IO_H

--- a/src/KC868A8_IO.cpp
+++ b/src/KC868A8_IO.cpp
@@ -1,0 +1,147 @@
+/*
+ * KC868-A8 I/O Abstraction Layer - Implementation
+ * 
+ * Hardware:
+ *   PCF8574 @ 0x24: 8-bit I/O expander for relay outputs
+ *     - ULN2003A driver: HIGH on PCF8574 = relay ON, LOW = relay OFF
+ *     - Active HIGH logic
+ * 
+ *   PCF8574 @ 0x22: 8-bit I/O expander for digital inputs
+ *     - Optocoupled inputs: LOW when triggered (circuit closed)
+ *     - Active LOW logic
+ *     - We invert so digitalRead returns HIGH when active
+ * 
+ * Virtual Pin Mapping:
+ *   100-107: Relay outputs (PCF8574 @ 0x24, bits 0-7)
+ *   110-117: Digital inputs (PCF8574 @ 0x22, bits 0-7)
+ *
+ * Polarity Convention:
+ *   digitalWrite/digitalRead are inverted for relay pins (100-107)
+ *   to match the ACTIVE_LOW convention used by the Pump-master library:
+ *     - digitalWrite(pin, 0) → relay ON (value LOW = active)
+ *     - digitalWrite(pin, 1) → relay OFF (value HIGH = inactive)
+ *     - digitalRead(pin) returns 0 when relay ON, 1 when OFF
+ *   This makes the KC868 layer transparent to libraries that assume
+ *   active-low relay modules (like the original ESP32 DevKit hardware).
+ *
+ *   Use setRelay()/getRelay() for direct hardware control (not inverted).
+ */
+
+#include "KC868A8_IO.h"
+
+// Undefine the macros here so we can define the actual member functions
+#undef digitalWrite
+#undef digitalRead
+#undef pinMode
+
+// Global instance
+KC868A8_IO KC868;
+
+KC868A8_IO::KC868A8_IO() 
+    : relayState(0x00),  // All relays OFF initially (LOW = OFF)
+      inputState(0x00),
+      lastInputState(0x00),
+      initialized(false) {
+}
+
+void KC868A8_IO::begin() {
+    // I2C should already be initialized (Wire.begin in Setup.cpp)
+    // Initialize relay outputs - all OFF
+    relayState = 0x00;  // All LOW = all relays OFF
+    Wire.beginTransmission(KC868_RELAY_I2C_ADDR);
+    Wire.write(relayState);
+    Wire.endTransmission();
+    
+    // Initialize inputs - read current state
+    readInputs();
+    lastInputState = inputState;
+    
+    initialized = true;
+    
+    Serial.println("[KC868-A8] I/O initialized: relays OFF, inputs read");
+}
+
+void KC868A8_IO::readInputs() {
+    Wire.requestFrom((uint16_t)KC868_INPUT_I2C_ADDR, (uint8_t)1);
+    if (Wire.available()) {
+        uint8_t raw = Wire.read();
+        // Optocoupled inputs are active LOW
+        // We store the inverted value so HIGH means "active"
+        inputState = ~raw;
+    }
+}
+
+void KC868A8_IO::writeOutputs() {
+    Wire.beginTransmission(KC868_RELAY_I2C_ADDR);
+    Wire.write(relayState);
+    Wire.endTransmission();
+}
+
+void KC868A8_IO::digitalWrite(uint8_t pin, uint8_t value) {
+    if (!initialized) return;
+    
+    if (IS_KC868_RELAY_PIN(pin)) {
+        uint8_t bit = pin - 100;
+        // Inverted logic: value=LOW(0) → relay ON, value=HIGH(1) → relay OFF
+        // This matches the ACTIVE_LOW convention used by Pump-master library
+        if (value) {
+            // value=HIGH → relay OFF (inactive for active-low relays)
+            relayState &= ~(1 << bit);
+        } else {
+            // value=LOW → relay ON (active for active-low relays)
+            relayState |= (1 << bit);
+        }
+        writeOutputs();
+    }
+    // Input pins: digitalWrite has no effect (read-only)
+}
+
+uint8_t KC868A8_IO::digitalRead(uint8_t pin) {
+    if (!initialized) return 0;
+    
+    if (IS_KC868_INPUT_PIN(pin)) {
+        readInputs();
+        uint8_t bit = pin - 110;
+        return (inputState >> bit) & 1;
+    }
+    
+    if (IS_KC868_RELAY_PIN(pin)) {
+        // Inverted read: returns 0 when relay ON, 1 when OFF
+        // This matches the ACTIVE_LOW convention used by Pump-master library
+        uint8_t bit = pin - 100;
+        return !((relayState >> bit) & 1);
+    }
+    
+    return 0;
+}
+
+void KC868A8_IO::pinMode(uint8_t pin, uint8_t mode) {
+    // Virtual pins don't need pinMode - managed by KC868 I/O layer
+    // This is intentionally empty
+}
+
+void KC868A8_IO::setRelay(uint8_t relayIndex, bool on) {
+    if (relayIndex > 7) return;
+    
+    if (on) {
+        relayState |= (1 << relayIndex);    // HIGH = relay ON
+    } else {
+        relayState &= ~(1 << relayIndex);   // LOW = relay OFF
+    }
+    writeOutputs();
+}
+
+bool KC868A8_IO::getRelay(uint8_t relayIndex) {
+    if (relayIndex > 7) return false;
+    return (relayState >> relayIndex) & 1;  // true = ON
+}
+
+bool KC868A8_IO::getInput(uint8_t inputIndex) {
+    if (inputIndex > 7) return false;
+    readInputs();
+    return (inputState >> inputIndex) & 1;  // true = active
+}
+
+void KC868A8_IO::printStatus() {
+    Serial.printf("[KC868-A8] Relays: 0x%02X, Inputs: 0x%02X\n", relayState, inputState);
+}

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -1,0 +1,694 @@
+#undef __STRICT_ANSI__              // work-around for Time Zone definition
+#include <stdint.h>                 // std lib (types definitions)
+#include <Arduino.h>                // Arduino framework
+#include <esp_sntp.h>
+#include <stdarg.h>
+#include "Config.h"
+#include "PoolMaster.h"
+#include "State_Machine.h"         // State machine for PoolMaster
+
+#ifdef KC868_A8
+  #include "KC868A8_IO.h"
+  #include "SensorSimulation.h"
+#endif
+
+
+
+// Firmware revision
+String Firmw = FIRMW;
+
+tm timeinfo;
+
+RunTimeData PMData =
+{ 
+  0, 0,
+  13,
+  0, 0,
+  3.0, 
+  0.0, 0.0,
+  28.0, 
+  7.2, 720., 1.3,
+  7.2, 720
+};
+
+// Various global flags
+volatile bool startTasks = false;               // Signal to start loop tasks
+
+// Store millis to allow Wifi Connection Timeout
+static unsigned long ConnectionTimeout = 0; // Last action time done on TFT. Go to sleep after TFT_SLEEP
+bool MDNSStatus = false;
+
+bool AntiFreezeFiltering = false;               // Filtration anti freeze mode
+//bool EmergencyStopFiltPump = false;             // flag will be (re)set by double-tapp button
+bool PSIError = false;                          // Water pressure OK
+bool cleaning_done = false;                     // daily cleaning done   
+
+// NTP & MQTT Connected
+bool PoolMaster_BoardReady = false;      // Is Board Up
+bool PoolMaster_WifiReady = false;      // Is Wifi Up
+bool PoolMaster_MQTTReady = false;      // Is MQTT Connected
+bool PoolMaster_NTPReady = false;      // Is NTP Connected
+bool PoolMaster_FullyLoaded = false;      // At startup gives time for everything to start before exiting Nextion's splash screen
+
+
+// Queue object to store incoming JSON commands (up to 10)
+QueueHandle_t queueIn;
+
+// NVS Non Volatile SRAM (eqv. EEPROM)
+Preferences nvs;      
+
+// Instanciations of Pump and PID objects to make them global. But the constructors are then called
+// before loading of the storage struct. At run time, the attributes take the default
+// values of the storage struct as they are compiled, just a few lines above, and not those which will 
+// be read from NVS later. This means that the correct objects attributes must be set later in
+// the setup function (fortunatelly, init methods exist).
+
+// The five pumps of the system (instanciate the Pump class)
+// In this case, all pumps start/Stop are managed by relays. pH, ORP, Robot and Electrolyse SWG pumps are interlocked with 
+// filtration pump
+// Pump class takes the following parameters:
+//    1/ The MCU relay output pin number to be switched by this pump
+//    2/ The MCU digital input pin number connected to the tank low level switch (can be NO_TANK or NO_LEVEL)
+//    3/ The relay level used for the pump. ACTIVE_HIGH if relay ON when digital output is HIGH and ACTIVE_LOW if relay ON when digital output is LOW.
+//    4/ The flow rate of the pump in Liters/Hour, typically 1.5 or 3.0 L/hour for peristaltic pumps for pools.
+//       This is used to estimate how much of the tank we have emptied out.
+//    5/ Tankvolume is used to compute the percentage of tank used/remaining
+// IMPORTANT NOTE: second argument is ID and MUST correspond to the equipment index in the "Pool_Equipment" vector
+// FiltrationPump: This Pump controls the filtration, no tank attached and not interlocked to any element. SSD relay attached works with HIGH level.
+
+Pump FiltrationPump(FILTRATION);
+// pHPump: This Pump has no low-level switch so remaining volume is estimated. It is interlocked with the relay of the FilrationPump
+//Pump PhPump(PH_PUMP, PH_LEVEL, ACTIVE_LOW, MODE_LATCHING, storage.pHPumpFR, storage.pHTankVol, storage.AcidFill);
+Pump PhPump(PH_PUMP,PH_LEVEL);
+// ChlPump: This Pump has no low-level switch so remaining volume is estimated. It is interlocked with the relay of the FilrationPump
+//Pump ChlPump(CHL_PUMP, CHL_LEVEL, ACTIVE_LOW, MODE_LATCHING, storage.ChlPumpFR, storage.ChlTankVol, storage.ChlFill);
+Pump ChlPump(CHL_PUMP,CHL_LEVEL);
+// RobotPump: This Pump is not injecting liquid so tank is associated to it. It is interlocked with the relay of the FilrationPump
+Pump RobotPump(ROBOT);
+// SWG: This Pump is associated with a Salt Water Chlorine Generator. It turns on and off the equipment to produce chlorine.
+// It has no tank associated. It is interlocked with the relay of the FilrationPump
+Pump SWGPump(SWG_PUMP);
+// Filling Pump: This pump is autonomous, not interlocked with filtering pump.
+Pump FillingPump(FILL_PUMP);
+
+// The Relays class to activate and deactivate digital pins
+Relay RELAYR0(PROJ,OUTPUT_DIGITAL); // Relay for the projector
+Relay RELAYR1(SPARE,OUTPUT_DIGITAL); // Relay for the spare
+
+// Input ports
+InputSensor PoolWaterLevelSensor(POOL_LEVEL); // Pool water level sensor (pool level ok if HIGH and pool level problem if LOW)
+
+// List of all the equipment of PoolMaster
+//std::vector<PIN*> Pool_Equipment;
+DeviceManager PoolDeviceManager;
+
+double pHValue = 0.0;                // pH value
+
+// PIDs instances
+//Specify the direction and initial tuning parameters
+PID PhPID(&PMData.PhValue, &PMData.PhPIDOutput, &PMData.Ph_SetPoint, 0, 0, 0, PhPID_DIRECTION);
+PID OrpPID(&PMData.OrpValue, &PMData.OrpPIDOutput, &PMData.Orp_SetPoint, 0, 0, 0, OrpPID_DIRECTION);
+
+// Publishing tasks handles to notify them
+static TaskHandle_t pubSetTaskHandle;
+static TaskHandle_t pubMeasTaskHandle;
+
+// Used for ElegantOTA
+//unsigned long ota_progress_millis = 0;
+
+// Configuration Manager
+ConfigManager PMConfig;
+
+// Mutex to share access to I2C bus among two tasks: AnalogPoll and StatusLights
+static SemaphoreHandle_t mutex;
+
+// Functions prototypes
+void StartTime(void);
+bool readLocalTime(void);
+//bool loadConfig(void);
+//bool saveConfig(void);
+void WiFiEvent(WiFiEvent_t);
+void initTimers(void);
+void InitWiFi(void);
+void ScanWiFiNetworks(void);
+void connectToWiFi(void);
+void mqttInit(void);                     
+void ResetTFT(void);
+void PublishSettings(void);
+void SetPhPID(bool);
+void SetOrpPID(bool);
+int  freeRam (void);
+void AnalogInit(void);
+void TempInit(void);
+unsigned stack_hwm();
+void stack_mon(UBaseType_t&);
+void info();
+
+// Functions used as Tasks
+void PoolMaster(void*);
+void AnalogPoll(void*);
+void pHRegulation(void*);
+void OrpRegulation(void*);
+void getTemp(void*);
+void ProcessCommand(void*);
+void SettingsPublish(void*);
+void MeasuresPublish(void*);
+void StatusLights(void*);
+
+#ifdef KC868_A8
+void AnalogSimLoop(void*);
+#endif
+void UpdateTFT(void*);
+void HistoryStats(void *);
+
+// For ElegantOTA
+/*void onOTAStart(void);
+void onOTAProgress(size_t,size_t);
+void onOTAEnd(bool);*/
+
+// Setup
+void setup()
+{
+  //Serial port for debug info
+  Serial.begin(115200);
+
+  // Set appropriate debug level. The level is defined in PoolMaster.h
+  Debug.setDebugLevel(DEBUG_LEVEL);
+  Debug.timestampOn();
+  Debug.debugLabelOn();
+  Debug.newlineOn();
+  Debug.formatTimestampOn();
+
+  //get board info
+  info();
+  Debug.print(DBG_INFO,"Booting PoolMaster Version: %s",FIRMW);
+  // Initialize Nextion TFT
+  #ifdef TFT_CONNECTED
+  ResetTFT();
+  #endif
+  PoolMaster_BoardReady = true;
+  /*
+  //Read ConfigVersion. If does not match expected value, restore default values
+  if(nvs.begin("PoolMaster",true))
+  {
+    uint8_t vers = nvs.getUChar("ConfigVersion",0);
+    Debug.print(DBG_INFO,"Stored version: %d",vers);
+    nvs.end();
+
+    if (vers == CONFIG_VERSION)
+    {
+      Debug.print(DBG_INFO,"Same version: %d / %d. Loading settings from NVS",vers,CONFIG_VERSION);
+      if(loadConfig()) Debug.print(DBG_INFO,"Config loaded"); //Restore stored values from NVS
+    }
+    else
+    {
+      Debug.print(DBG_INFO,"New version: %d / %d. Loading new default settings",vers,CONFIG_VERSION);      
+      if(saveConfig()) Debug.print(DBG_INFO,"Config saved");  //First time use. Save new default values to NVS
+    }
+
+  } else {
+    Debug.print(DBG_ERROR,"NVS Error");
+    nvs.end();
+    Debug.print(DBG_INFO,"New version: %d. First saving of settings",CONFIG_VERSION);      
+      if(saveConfig()) Debug.print(DBG_INFO,"Config saved");  //First time use. Save new default values to NVS
+  }  
+*/
+  // Initialize configuration manager
+  // List of parameters are in PoolMaster.h, in the ParamID enum
+  // Please update the list if you add new parameters
+  // Supported types are: bool, uint8_t, unsigned long, double, char* and uint32_t
+  PMConfig.SetNamespace(CONFIG_NVS_NAME);
+  PMConfig.initParam(AUTOMODE,            "AutoMode",               false);
+  PMConfig.initParam(WINTERMODE,          "WinterMode",             false);
+  PMConfig.initParam(FILTRATIONSTART,     "FiltrStart",             (uint8_t)8); 
+  PMConfig.initParam(FILTRATIONSTOP,      "FiltrStop",              (uint8_t)20); 
+  PMConfig.initParam(FILTRATIONSTARTMIN,  "FiltrStartMin",          (uint8_t)8); 
+  PMConfig.initParam(FILTRATIONSTOPMAX,   "FiltrStopMax",           (uint8_t)22); 
+  PMConfig.initParam(DELAYPIDS,           "DelayPIDs",              (uint8_t)15); 
+  PMConfig.initParam(PUBLISHPERIOD,       "PublishPeriod",          (unsigned long)PUBLISHINTERVAL);
+  PMConfig.initParam(PHPIDWINDOWSIZE,     "PhPIDWSize",             (unsigned long)60000);
+  PMConfig.initParam(ORPPIDWINDOWSIZE,    "OrpPIDWSize",            (unsigned long)30000);
+  PMConfig.initParam(PH_SETPOINT,         "PhSetPoint",             (double)7.2);
+  PMConfig.initParam(ORP_SETPOINT,        "OrpSetPoint",            (double)750.0);
+  PMConfig.initParam(PSI_HIGHTHRESHOLD,   "PSIHigh",                (double)0.5);
+  PMConfig.initParam(PSI_MEDTHRESHOLD,    "PSIMed",                 (double)0.25);
+  PMConfig.initParam(WATERTEMPLOWTHRESHOLD,"WaterTempLow",          (double)10.0);
+  PMConfig.initParam(WATERTEMP_SETPOINT,  "WaterTempSet",           (double)27.0);
+  #ifdef EXT_ADS1115
+    PMConfig.initParam(PHCALIBCOEFFS0,      "pHCalibCoeffs0",         (double)-2.50133333);
+    PMConfig.initParam(PHCALIBCOEFFS1,      "pHCalibCoeffs1",         (double)6.9);
+    PMConfig.initParam(ORPCALIBCOEFFS0,     "OrpCalibCoeffs0",        (double)431.03);
+    PMConfig.initParam(ORPCALIBCOEFFS1,     "OrpCalibCoeffs1",        (double)0.0);
+  #else
+    PMConfig.initParam(PHCALIBCOEFFS0,      "pHCalibCoeffs0",         (double)0.9583);
+    PMConfig.initParam(PHCALIBCOEFFS1,      "pHCalibCoeffs1",         (double)4.834);
+    PMConfig.initParam(ORPCALIBCOEFFS0,     "OrpCalibCoeffs0",        (double)129.2);
+    PMConfig.initParam(ORPCALIBCOEFFS1,     "OrpCalibCoeffs1",        (double)384.1);
+  #endif
+  PMConfig.initParam(PSICALIBCOEFFS0,     "PSICalibCoeffs0",        (double)0.377923399);
+  PMConfig.initParam(PSICALIBCOEFFS1,     "PSICalibCoeffs1",        (double)-0.17634473);
+  //Default values for pH and ORP PIDs
+  // si pH+ : Kp=2250000.
+  // si pH- : Kp=2700000.
+  PMConfig.initParam(PH_KP,               "PhKp",                   (double)2700000.0);
+  PMConfig.initParam(PH_KI,               "PhKi",                   (double)0.0);
+  PMConfig.initParam(PH_KD,               "PhKd",                   (double)0.0);
+  PMConfig.initParam(ORP_KP,              "OrpKp",                  (double)2500.0);
+  PMConfig.initParam(ORP_KI,              "OrpKi",                  (double)0.0);
+  PMConfig.initParam(ORP_KD,              "OrpKd",                  (double)0.0);
+  PMConfig.initParam(SECUREELECTRO,       "SecureElectro",          (uint8_t)15);
+  PMConfig.initParam(DELAYELECTRO,        "DelayElectro",           (uint8_t)2);
+  PMConfig.initParam(ELECTRORUNMODE,      "ElectroRunMode",         (bool)SWG_MODE_ADJUST);
+  PMConfig.initParam(ELECTRORUNTIME,      "ElectroRunTime",         (uint8_t)8);
+  PMConfig.initParam(ELECTROLYSEMODE,     "ElectrolyseMode",        (bool)false);
+  PMConfig.initParam(PHAUTOMODE,          "PhAutoMode",             (bool)false);
+  PMConfig.initParam(ORPAUTOMODE,         "OrpAutoMode",            (bool)false);
+  PMConfig.initParam(FILLAUTOMODE,        "FillAutoMode",           (bool)false);
+  PMConfig.initParam(LANG_LOCALE,         "LangLocale",             (uint8_t)0);
+  PMConfig.initParam(MQTT_IP,             "MqttIP",                 (uint32_t)IPAddress(192,168,0,0));
+  PMConfig.initParam(MQTT_PORT,           "MqttPort",               (uint32_t)1883);
+  PMConfig.initParam(MQTT_LOGIN,          "MqttLogin",              (char*)"");
+  PMConfig.initParam(MQTT_PASS,           "MqttPass",               (char*)"");
+  PMConfig.initParam(MQTT_ID,             "MqttId",                 (char*)MQTTID);
+  PMConfig.initParam(MQTT_TOPIC,          "MqttTopic",              (char*)POOLTOPIC);
+  PMConfig.initParam(SMTP_SERVER,         "SmtpServer",             (char*)"");
+  PMConfig.initParam(SMTP_PORT,           "SmtpPort",               (uint32_t)587);
+  PMConfig.initParam(SMTP_LOGIN,          "SmtpLogin",              (char*)"");
+  PMConfig.initParam(SMTP_PASS,           "SmtpPass",               (char*)"");
+  PMConfig.initParam(SMTP_SENDER,         "SmtpSender",             (char*)"");
+  PMConfig.initParam(SMTP_RECIPIENT,      "SmtpRecipient",          (char*)"");
+  PMConfig.initParam(BUZZERON,            "BuzzerOn",               (bool)true);
+  // End of configuration manager initialization
+
+  PMConfig.printAllParams(); // Print all parameters to Serial for debug
+
+  //Define pins directions
+#if BUZZER != 255
+  pinMode(BUZZER, OUTPUT);
+#endif
+
+  // Warning: pins used here have no pull-ups, provide external ones
+  // On KC868-A8, these are virtual pins via PCF8574 - pinMode handled by I/O layer
+  pinMode(CHL_LEVEL, INPUT);
+  pinMode(PH_LEVEL, INPUT);
+
+  // Initialize default's devices name
+  FiltrationPump.SetName("Filtration Pump");
+  PhPump.SetName("pH Pump");
+  ChlPump.SetName("Chlorine Pump");
+  RobotPump.SetName("Robot Pump");
+  SWGPump.SetName("SWG Pump");
+  FillingPump.SetName("Filling Pump");
+  RELAYR0.SetName("Projector Relay");
+  RELAYR1.SetName("Spare Relay");
+  PoolWaterLevelSensor.SetName("Water Level Sensor");
+
+  // Sets all default values for the pumps. If preferences are loaded from NVS, these values will be overwritten on a value per value basis.
+  PhPump.SetInterlock(DEVICE_FILTPUMP); // pH Pump interlocked with Filtration Pump
+  ChlPump.SetInterlock(DEVICE_FILTPUMP); // Chlorine Pump interlocked with Filtration Pump
+  RobotPump.SetInterlock(DEVICE_FILTPUMP); // Robot Pump interlocked with Filtration Pump
+  SWGPump.SetInterlock(DEVICE_FILTPUMP); // SWG Pump interlocked
+  
+  // Default values for the pumps
+  FillingPump.SetMinUpTime(5*60*1000);  // Minimum running uptime for Filling Pump is 5 minutes (avoir short runs)
+  FiltrationPump.SetMaxUpTime(0); // No Maximum uptime for Filtration Pump
+
+  // Initialize the state machine handlers for the pumps
+  FillingPump.SetHandlers(FillingPump_StartCondition,FillingPump_StopCondition,FillingPump_StartAction,FillingPump_StopAction);
+  FiltrationPump.SetHandlers(FiltrationPump_StartCondition,FiltrationPump_StopCondition,FiltrationPump_StartAction,FiltrationPump_StopAction);
+  FiltrationPump.SetLoopHandler(FiltrationPump_LoopActions);
+  RobotPump.SetHandlers(RobotPump_StartCondition,RobotPump_StopCondition,RobotPump_StartAction,RobotPump_StopAction);
+  SWGPump.SetHandlers(SWGPump_StartCondition,SWGPump_StopCondition,SWGPump_StartAction,SWGPump_StopAction);
+
+  // Fill DeviceManager with the list of devices
+  PoolDeviceManager.AddDevice(DEVICE_FILTPUMP,&FiltrationPump);
+  PoolDeviceManager.AddDevice(DEVICE_PH_PUMP,&PhPump);
+  PoolDeviceManager.AddDevice(DEVICE_CHL_PUMP,&ChlPump);
+  PoolDeviceManager.AddDevice(DEVICE_ROBOT,&RobotPump);
+  PoolDeviceManager.AddDevice(DEVICE_SWG,&SWGPump);
+  PoolDeviceManager.AddDevice(DEVICE_FILLING_PUMP,&FillingPump);
+  PoolDeviceManager.AddDevice(DEVICE_RELAY0,&RELAYR0);
+  PoolDeviceManager.AddDevice(DEVICE_RELAY1,&RELAYR1);
+  PoolDeviceManager.AddDevice(DEVICE_POOL_LEVEL,&PoolWaterLevelSensor);
+
+  // Load configuration parameters from NVS for all devices
+  PoolDeviceManager.LoadPreferences();
+  PoolDeviceManager.InitDevicesInterlock();
+  PoolDeviceManager.Begin();
+
+  // Initialize watch-dog
+  esp_task_wdt_init(WDT_TIMEOUT, true);
+
+  //Initialize MQTT
+  mqttInit();
+
+  // Initialize WiFi events management (on connect/disconnect)
+  WiFi.onEvent(WiFiEvent);
+  initTimers();
+  InitWiFi();
+  connectToWiFi();
+
+  delay(500);    // let task start-up and wait for connection
+  ConnectionTimeout = millis();
+  while((WiFi.status() != WL_CONNECTED)&&((unsigned long)(millis() - ConnectionTimeout) < WIFI_TIMEOUT)) {
+    delay(500);
+    Serial.print(".");
+  }
+  
+  // Start I2C for ADS1115 and status lights through PCF8574A
+  Wire.begin(I2C_SDA,I2C_SCL);
+
+#ifdef KC868_A8
+  // Initialize KC868-A8 I/O layer AFTER Wire.begin() for I2C communication.
+  // KC868.begin() writes to PCF8574 to turn all relays OFF.
+  KC868.begin();
+  
+  // Initialize sensor simulation system
+  SimSensor.begin();
+#endif
+
+  // Init pH, ORP and PSI analog measurements
+  AnalogInit();
+
+  // Init Water and Air temperatures measurements
+  TempInit();
+
+  // Clear status LEDs
+  Wire.beginTransmission(PCF8574ADDRESS);
+  Wire.write((uint8_t)0xFF);
+  Wire.endTransmission();
+
+  // Initialize PIDs
+  PMData.PhPIDwStart  = millis();
+  PMData.OrpPIDwStart  = millis();
+
+  // Limit the PIDs output range in order to limit max. pumps runtime (safety first...)
+  PhPID.SetTunings(PMConfig.get<double>(PH_KP), PMConfig.get<double>(PH_KI), PMConfig.get<double>(PH_KD));
+  PhPID.SetControllerDirection(PhPID_DIRECTION);
+  PhPID.SetSampleTime((int)PMConfig.get<unsigned long>(PHPIDWINDOWSIZE));
+  PhPID.SetOutputLimits(0, PMConfig.get<unsigned long>(PHPIDWINDOWSIZE));    //Whatever happens, don't allow continuous injection of Acid for more than a PID Window
+
+  OrpPID.SetTunings(PMConfig.get<double>(ORP_KP), PMConfig.get<double>(ORP_KI), PMConfig.get<double>(ORP_KD));
+  OrpPID.SetControllerDirection(OrpPID_DIRECTION);
+  OrpPID.SetSampleTime((int)PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE));
+  OrpPID.SetOutputLimits(0, PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE));  //Whatever happens, don't allow continuous injection of Chl for more than a PID Window
+
+  // PIDs off at start
+  SetPhPID (false);
+  SetOrpPID(false);
+
+   // Create queue for external commands
+  queueIn = xQueueCreate((UBaseType_t)QUEUE_ITEMS_NBR,(UBaseType_t)QUEUE_ITEM_SIZE);
+
+  // Create loop tasks in the scheduler.
+  //------------------------------------
+  int app_cpu = xPortGetCoreID();
+
+  Debug.print(DBG_DEBUG,"Creating loop Tasks");
+
+  // Create I2C sharing mutex
+  mutex = xSemaphoreCreateMutex();
+
+  // Analog measurement polling task
+  xTaskCreatePinnedToCore(
+    AnalogPoll,
+    "AnalogPoll",
+    3072,
+    NULL,
+    1,
+    nullptr,
+    app_cpu
+  );
+
+  // MQTT commands processing
+  xTaskCreatePinnedToCore(
+    ProcessCommand,
+    "ProcessCommand",
+    3584,
+    NULL,
+    1,
+    nullptr,
+    app_cpu
+  );
+
+  // PoolMaster: Supervisory task
+  xTaskCreatePinnedToCore(
+    PoolMaster,
+    "PoolMaster",
+    5120,
+    NULL,
+    1,
+    nullptr,
+    app_cpu
+  );
+
+  // Temperatures measurement
+  xTaskCreatePinnedToCore(
+    getTemp,
+    "GetTemp",
+    3072,
+    NULL,
+    1,
+    nullptr,
+    app_cpu
+  );
+  
+ // ORP regulation loop
+    xTaskCreatePinnedToCore(
+    OrpRegulation,
+    "ORPRegulation",
+    2048,
+    NULL,
+    1,
+    nullptr,
+    app_cpu
+  );
+
+  // pH regulation loop
+    xTaskCreatePinnedToCore(
+    pHRegulation,
+    "pHRegulation",
+    2048,
+    NULL,
+    1,
+    nullptr,
+    app_cpu
+  );
+
+  // Status lights display
+  xTaskCreatePinnedToCore(
+    StatusLights,
+    "StatusLights",
+    2048,
+    NULL,
+    1,
+    nullptr,
+    app_cpu
+  );
+
+#ifdef KC868_A8
+  // Analog sensor simulation loop (pH/ORP dynamic simulation)
+  xTaskCreatePinnedToCore(
+    AnalogSimLoop,
+    "AnalogSimLoop",
+    2048,
+    NULL,
+    1,
+    nullptr,
+    app_cpu
+  );
+#endif
+
+  // Measures MQTT publish 
+  xTaskCreatePinnedToCore(
+    MeasuresPublish,
+    "MeasuresPublish",
+    3072,
+    NULL,
+    1,
+    &pubMeasTaskHandle,               // needed to notify task later
+    app_cpu
+  );
+
+  // MQTT Settings publish 
+  xTaskCreatePinnedToCore(
+    SettingsPublish,
+    "SettingsPublish",
+    3584,
+    NULL,
+    1,
+    &pubSetTaskHandle,                // needed to notify task later
+    app_cpu
+  );
+
+  // NEXTION Screen Update
+  #ifdef TFT_CONNECTED
+  xTaskCreatePinnedToCore(
+    UpdateTFT,
+    "UpdateTFT",
+    3072,
+    NULL,
+    1,
+    nullptr, 
+    app_cpu
+  );
+  #endif
+
+  // History Stats Storage
+  xTaskCreatePinnedToCore(
+    HistoryStats,
+    "HistoryStats",
+    2048,
+    NULL,
+    1,
+    nullptr,
+    app_cpu
+  );
+
+#ifdef ELEGANT_OTA
+// ELEGANTOTA Configuration
+  server.on("/", []() {
+  server.send(200, "text/plain", "NA");
+  });
+  ElegantOTA.begin(&server);    // Start ElegantOTA
+  ElegantOTA.onStart(onOTAStart);
+  ElegantOTA.onProgress(onOTAProgress);
+  ElegantOTA.onEnd(onOTAEnd);
+  server.begin();
+  Serial.println("HTTP server started");
+  // Set Authentication Credentials
+#ifdef ELEGANT_OTA_AUTH
+  ElegantOTA.setAuth(ELEGANT_OTA_USERNAME, ELEGANT_OTA_PASSWORD);
+#endif
+#endif
+
+  // Initialize OTA (On The Air update)
+  //-----------------------------------
+  ArduinoOTA.setPort(OTA_PORT);
+  ArduinoOTA.setHostname("PoolMaster");
+  ArduinoOTA.setPasswordHash(OTA_PWDHASH);
+  
+  ArduinoOTA.onStart([]() {
+    String type;
+    if (ArduinoOTA.getCommand() == U_FLASH)
+      type = "sketch";
+    else // U_SPIFFS
+      type = "filesystem";
+    Debug.print(DBG_INFO,"Start updating %s",type);
+  });
+  ArduinoOTA.onEnd([]() {
+  Debug.print(DBG_INFO,"End");
+  });
+  ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
+    esp_task_wdt_reset();           // reset Watchdog as upload may last some time...
+    Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
+  });
+  ArduinoOTA.onError([](ota_error_t error) {
+    Debug.print(DBG_ERROR,"Error[%u]: ", error);
+    if      (error == OTA_AUTH_ERROR)    Debug.print(DBG_ERROR,"Auth Failed");
+    else if (error == OTA_BEGIN_ERROR)   Debug.print(DBG_ERROR,"Begin Failed");
+    else if (error == OTA_CONNECT_ERROR) Debug.print(DBG_ERROR,"Connect Failed");
+    else if (error == OTA_RECEIVE_ERROR) Debug.print(DBG_ERROR,"Receive Failed");
+    else if (error == OTA_END_ERROR)     Debug.print(DBG_ERROR,"End Failed");
+  });
+
+  ArduinoOTA.begin();
+
+  //display remaining RAM/Heap space.
+  Debug.print(DBG_DEBUG,"[memCheck] Stack: %d bytes - Heap: %d bytes",stack_hwm(),freeRam());
+
+  // Start loops tasks
+  Debug.print(DBG_INFO,"Init done, starting loop tasks");
+  startTasks = true;
+
+  delay(1000);          // wait for tasks to start
+}
+
+//Compute free RAM
+//useful to check if it does not shrink over time
+int freeRam () {
+  int v = xPortGetFreeHeapSize();
+  return v;
+}
+
+// Get current free stack 
+unsigned stack_hwm(){
+  return uxTaskGetStackHighWaterMark(nullptr);
+}
+
+// Monitor free stack (display smallest value)
+void stack_mon(UBaseType_t &hwm)
+{
+  UBaseType_t temp = uxTaskGetStackHighWaterMark(nullptr);
+  if(!hwm || temp < hwm)
+  {
+    hwm = temp;
+    Debug.print(DBG_DEBUG,"[stack_mon] %s: %d bytes",pcTaskGetTaskName(NULL), hwm);
+  }  
+}
+
+// Get exclusive access of I2C bus
+void lockI2C(){
+  xSemaphoreTake(mutex, portMAX_DELAY);
+}
+
+// Release I2C bus access
+void unlockI2C(){
+  xSemaphoreGive(mutex);  
+}
+
+// Set time parameters, including DST
+void StartTime(){
+  configTime(0, 0,"0.pool.ntp.org","1.pool.ntp.org","2.pool.ntp.org"); // 3 possible NTP servers
+  setenv("TZ","CET-1CEST,M3.5.0/2,M10.5.0/3",3);                       // configure local time with automatic DST  
+  tzset();
+  int retry = 0;
+  const int retry_count = 15;
+  while(sntp_get_sync_status() == SNTP_SYNC_STATUS_RESET && ++retry < retry_count){
+    vTaskDelay(2000 / portTICK_PERIOD_MS);
+  }
+  Debug.print(DBG_INFO,"NTP configured");
+}
+
+bool readLocalTime(){
+  if(!getLocalTime(&timeinfo,5000U)){
+    Debug.print(DBG_WARNING,"Failed to obtain time");
+    return false;
+  }
+  //Debug.print("%A, %B %d %Y %H:%M:%S",&timeinfo);
+  return true;
+}
+
+// Notify PublishSettings task 
+void PublishSettings()
+{
+  xTaskNotifyGive(pubSetTaskHandle);
+}
+
+// Notify PublishMeasures task
+void PublishMeasures()
+{
+  xTaskNotifyGive(pubMeasTaskHandle);
+}
+
+//board info
+void info(){
+  esp_chip_info_t out_info;
+  esp_chip_info(&out_info);
+  Debug.print(DBG_INFO,"CPU frequency       : %dMHz",ESP.getCpuFreqMHz());
+  Debug.print(DBG_INFO,"CPU Cores           : %d",out_info.cores);
+  Debug.print(DBG_INFO,"Flash size          : %dMB",ESP.getFlashChipSize()/1000000);
+  Debug.print(DBG_INFO,"Free RAM            : %d bytes",ESP.getFreeHeap());
+  Debug.print(DBG_INFO,"Min heap            : %d bytes",esp_get_free_heap_size());
+  Debug.print(DBG_INFO,"tskIDLE_PRIORITY    : %d",tskIDLE_PRIORITY);
+  Debug.print(DBG_INFO,"confixMAX_PRIORITIES: %d",configMAX_PRIORITIES);
+  Debug.print(DBG_INFO,"configTICK_RATE_HZ  : %d",configTICK_RATE_HZ);
+}
+
+
+// Pseudo loop, which deletes loopTask of the Arduino framework
+void loop()
+{
+  delay(1000);
+  vTaskDelete(nullptr);
+}


### PR DESCRIPTION
## Fix: KC868 Relay-Polarity und UpTime-Akkumulation

### Problem
Das UpTime der Pumpen läuft von Boot an, auch wenn die Pumpen physisch AUS sind. Die Relais werden bei Start in die falsche Richtung geschaltet.

### Root Cause
Drei Bugs in der KC868-A8 I/O Schicht:

1. **`digitalWrite`/`digitalRead` invertiert nicht für ACTIVE_LOW**: Die Pump-master Library nutzt `ACTIVE_LOW` (active_level=0):
   - `Enable()` ruft `digitalWrite(pin, 0)` auf → Relais EIN
   - `IsActive()` prüft `digitalRead(pin) == 0` → Relais läuft
   
   KC868 gab aber 1=ON zurück → komplett invertierte Logik:
   - Pumpen denken sie laufen, wenn Relais AUS ist → UpTime akkumuliert
   - `Enable()` schaltet Relais AUS statt EIN
   - `Disable()` schaltet Relais EIN statt AUS

2. **`KC868.begin()` vor `Wire.begin()`**: I2C nicht initialisiert → `digitalWrite` in `PIN::Begin()` ist no-op → Relais-Zustand unbekannt

3. **`setRelay()` Bit-Shift Bug**: `relayState &= ~(relayIndex)` statt `~(1 << relayIndex)` → falsche Bit-Manipulation für Index > 0

### Fixes

**`src/KC868A8_IO.cpp`:**
- `digitalWrite`: Invertierte Logik für Relais-Pins (value=0 → EIN, value=1 → AUS)
- `digitalRead`: Invertierte Rückgabe für Relais-Pins (0 = Relais EIN)
- `setRelay()`: Bug fix `~(relayIndex)` → `~(1 << relayIndex)`

**`src/Setup.cpp`:**
- `KC868.begin()` nach `Wire.begin()` verschoben (I2C muss zuerst initialisiert sein)
- Redundante `setRelay(i, true)` Schleife entfernt (KC868.begin() initialisiert alles korrekt)

**`include/KC868A8_IO.h`:**
- Header-Kommentare aktualisiert

### Betrifft
- Nur KC868-A8 Hardware (`#ifdef KC868_A8`)
- ESP32 DevKit Build nicht betroffen (nutzt direkte GPIO, keine Invertierung nötig)

### Test
- [ ] Boot: Alle Relais AUS nach Start
- [ ] Pumpen starten/stoppen in die richtige Richtung
- [ ] UpTime läuft nur wenn Pumpe physisch EIN ist
- [ ] `setRelay()` funktioniert korrekt für alle 8 Relais
- [ ] ESP32 DevKit Build funktioniert unverändert