### PR TITLE
fix(kc868a8): Invert relay logic for Pump-master ACTIVE_LOW compatibility

### DIFF
--- a/lib/Pump-master/src/KC868A8_IO.h
+++ b/lib/Pump-master/src/KC868A8_IO.h
@@ -5,8 +5,10 @@
  * Virtual pins (100+) are mapped to PCF8574 I2C expanders.
  * 
  * Relay outputs (100-107): PCF8574 @ 0x24, active LOW via ULN2003A
- *   - digitalWrite(pin, HIGH) → relay ON → PCF8574 bit = LOW
- *   - digitalWrite(pin, LOW)  → relay OFF → PCF8574 bit = HIGH
+ *   - digitalWrite(pin, 0) → relay ON (PCF8574 bit = HIGH)
+ *   - digitalWrite(pin, 1) → relay OFF (PCF8574 bit = LOW)
+ *   - digitalRead(pin) returns 0 when relay ON, 1 when OFF
+ *   - Inverted for Pump-master ACTIVE_LOW compatibility
  * 
  * Digital inputs (110-117): PCF8574 @ 0x22, active LOW
  *   - digitalRead(pin) → HIGH = inactive, LOW = active (optocoupler triggered)

--- a/src/KC868A8_IO.cpp
+++ b/src/KC868A8_IO.cpp
@@ -4,7 +4,9 @@
  * Hardware:
  *   PCF8574 @ 0x24: 8-bit I/O expander for relay outputs
  *     - ULN2003A driver: HIGH on PCF8574 = relay ON, LOW = relay OFF
- *     - Active HIGH logic
+ *     - Physical: active HIGH (PCF8574 HIGH → relay ON)
+ *     - digitalWrite/digitalRead: inverted for Pump-master ACTIVE_LOW compat
+ *       (value 0 = relay ON, value 1 = relay OFF)
  * 
  *   PCF8574 @ 0x22: 8-bit I/O expander for digital inputs
  *     - Optocoupled inputs: LOW when triggered (circuit closed)
@@ -71,12 +73,13 @@ void KC868A8_IO::digitalWrite(uint8_t pin, uint8_t value) {
     
     if (IS_KC868_RELAY_PIN(pin)) {
         uint8_t bit = pin - 100;
+        // Inverted for Pump-master ACTIVE_LOW compatibility:
+        // value 0 → relay ON (PCF8574 HIGH via ULN2003A)
+        // value 1 → relay OFF (PCF8574 LOW)
         if (value) {
-            // Relay ON → PCF8574 bit HIGH
-            relayState |= (1 << bit);
+            relayState &= ~(1 << bit);   // value=1 → relay OFF
         } else {
-            // Relay OFF → PCF8574 bit LOW
-            relayState &= ~(1 << bit);
+            relayState |= (1 << bit);    // value=0 → relay ON
         }
         writeOutputs();
     }
@@ -93,9 +96,10 @@ uint8_t KC868A8_IO::digitalRead(uint8_t pin) {
     }
     
     if (IS_KC868_RELAY_PIN(pin)) {
-        // Read current relay state
+        // Inverted for Pump-master ACTIVE_LOW compatibility:
+        // returns 0 when relay is ON, 1 when relay is OFF
         uint8_t bit = pin - 100;
-        return (relayState >> bit) & 1;  // HIGH = relay ON
+        return !((relayState >> bit) & 1);
     }
     
     return 0;

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -282,15 +282,7 @@ void setup()
 
   PMConfig.printAllParams(); // Print all parameters to Serial for debug
 
-#ifdef KC868_A8
-  // Initialize KC868-A8 I/O layer (PCF8574 expanders)
-  KC868.begin();
-  
-  // Initialize sensor simulation system
-  SimSensor.begin();
-#endif
-
-  //Define pins directions
+//Define pins directions
 #if BUZZER != 255
   pinMode(BUZZER, OUTPUT);
 #endif
@@ -378,12 +370,12 @@ void setup()
   Wire.endTransmission();
 
 #ifdef KC868_A8
-  // Wire is now initialized — explicitly turn all relays OFF.
-  // KC868.begin() ran before Wire.begin() so its I2C write never reached hardware.
-  for (uint8_t i = 0; i < 8; i++) {
-    KC868.setRelay(i, true);
-  }
-  Debug.print(DBG_INFO,"[KC868-A8] All relays set to OFF (boot reset)");
+  // Initialize KC868-A8 I/O layer (PCF8574 expanders)
+  // Must be after Wire.begin() — I2C must be initialized first
+  KC868.begin();
+  
+  // Initialize sensor simulation system
+  SimSensor.begin();
 #endif
 
   // Initialize PIDs


### PR DESCRIPTION
## Three bugs fixed

### 1. digitalWrite/digitalRead inverted for relay pins

The Pump-master library defaults to `ACTIVE_LOW` (active_level=0), meaning:
- `Enable()` writes `digitalWrite(pin, 0)` to turn ON
- `IsActive()` checks `digitalRead(pin) == 0` to confirm ON

The KC868 layer was passing values directly to the PCF8574 — so writing 0 turned the relay **OFF** and reading returned 1 when ON. Completely inverted → pumps thought they were running when stopped and vice versa.

**Fix:** Invert relay logic in `digitalWrite()` (0→ON, 1→OFF) and `digitalRead()` (returns 0 when relay ON).

### 2. KC868.begin() called before Wire.begin()

`KC868.begin()` ran at line 287, but `Wire.begin()` wasn't called until line 367. The I2C relay state write was a no-op. The existing workaround loop called `setRelay(i, true)` but the comment said "set to OFF" — wrong in both timing and logic.

**Fix:** Move `KC868.begin()` + `SimSensor.begin()` after `Wire.begin()`, remove the broken workaround.

### 3. setRelay bit-shift — already correct

The code already uses `~(1 << relayIndex)` — no change needed.

---

**Files changed:** `src/KC868A8_IO.cpp`, `src/Setup.cpp`, `lib/Pump-master/src/KC868A8_IO.h`