### PR TITLE
fix(pump): Dual-Core Race Condition fix + Debug-Ausgaben für UpTime-Analyse

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -30,7 +30,7 @@
 
 //Version of config stored in EEPROM
 //Random value. Change this value (to any other value) to revert the config to default values
-#define CONFIG_VERSION 50
+#define CONFIG_VERSION 20
 
 // ============================================================
 // TFT DISPLAY CONFIGURATION

--- a/include/Config.h
+++ b/include/Config.h
@@ -58,8 +58,8 @@
 #define SIMU_PH_VALUE       7.2     // Default simulated pH
 #define SIMU_ORP_VALUE      720.0   // Default simulated ORP (mV)
 #define SIMU_PSI_VALUE      0.1    // Default simulated pressure (bar)
-#define SIMU_CHL_LEVEL_VALUE  0     // Default: Low (tank not empty)
-#define SIMU_PH_LEVEL_VALUE   0     // Default: Low (tank not empty)
+#define SIMU_CHL_LEVEL_VALUE  1     // Default: Low (tank not empty)
+#define SIMU_PH_LEVEL_VALUE   1      // Default: Low (tank not empty)
 #define SIMU_POOL_LEVEL_VALUE 1     // Default: HIGH (pool level OK)
 
 // ============================================================

--- a/include/Config.h
+++ b/include/Config.h
@@ -18,6 +18,9 @@
 
 // Firmware revisions
 #define FIRMW "ESP-4.62"
+#ifndef GIT_COMMIT_HASH
+#define GIT_COMMIT_HASH "unknown"
+#endif
 #define TFT_FIRMW "TFT-4.0" // For compatibility
 
 // Choose Nextion version to Compile (only one choice possible)

--- a/include/Config.h
+++ b/include/Config.h
@@ -58,8 +58,8 @@
 #define SIMU_PH_VALUE       7.2     // Default simulated pH
 #define SIMU_ORP_VALUE      720.0   // Default simulated ORP (mV)
 #define SIMU_PSI_VALUE      0.1    // Default simulated pressure (bar)
-#define SIMU_CHL_LEVEL_VALUE  1     // Default: Low (tank not empty)
-#define SIMU_PH_LEVEL_VALUE   1      // Default: Low (tank not empty)
+#define SIMU_CHL_LEVEL_VALUE  0     // Default: Low (tank not empty)
+#define SIMU_PH_LEVEL_VALUE   0      // Default: Low (tank not empty)
 #define SIMU_POOL_LEVEL_VALUE 1     // Default: HIGH (pool level OK)
 
 // ============================================================

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -89,13 +89,18 @@ u_int8_t Pump::Start(bool _resetUpTime)
     GetPinNumber(), (int)IsRunning(), UpTime, UpTime / 1000, millis(), bitMaskErrors);
 #endif
 
+  // [FIX-A] Always update LastLoopMillis BEFORE checking relay state.
+  // Previously, this was inside the if(!IsRunning()) block, which meant
+  // LastLoopMillis stayed at 0 (from constructor or ResetUpTime) when:
+  //   1) First-ever Start() after boot with relay already ON (from Preferences)
+  //   2) Redundant Start() command while pump is already running
+  //   3) After midnight ResetUpTime() while pump is running
+  // In all these cases, loop() would calculate UpTime += millis() - 0,
+  // adding the entire board uptime in a single iteration.
+  LastLoopMillis = millis();
+
   if((!IsRunning()) && !UpTimeError && TankLevel() && CheckInterlock())
   {
-    // CRITICAL: Set LastLoopMillis BEFORE Enable() to prevent race condition.
-    // On dual-core ESP32, Pump::loop() on the other core can read stale
-    // LastLoopMillis=0 during the I2C Enable() call, causing UpTime to
-    // jump by the entire board uptime in a single iteration.
-    LastLoopMillis = millis();
     if (!this->Relay::Enable()) {
       bitMaskErrors |= (1 << 3); // Bit 3: Relay error
 #ifdef KC868_A8
@@ -246,10 +251,21 @@ void Pump::SetMinUpTime(unsigned long _minuptime)
 //This is typically called every day at midnight
 void Pump::ResetUpTime()
 {
-  StartTime = LastLoopMillis = 0;
+  StartTime = 0;
   StopTime = 0;
   UpTime = 0;
   CurrMaxUpTime = MaxUpTime;
+
+  // [FIX-B] Only reset LastLoopMillis to 0 if pump is NOT running.
+  // Previously, this unconditionally set LastLoopMillis = 0.
+  // When called at midnight (PoolMaster daily reset) while pump is running,
+  // the next loop() would calculate UpTime += millis() - 0,
+  // adding the entire board uptime in one iteration.
+  if (!IsRunning()) {
+    LastLoopMillis = 0;
+  } else {
+    LastLoopMillis = millis();
+  }
 }
 
 //Clear "UpTimeError" error flag and allow the pump to run for an extra MaxUpTime

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -10,21 +10,6 @@ void Pump::loop()
 {
   u_int8_t bitMaskErrors = 0;
 
-#ifdef KC868_A8
-  // Periodic debug output (every 5s) to track UpTime accumulation
-  static unsigned long lastDbgLoop = 0;
-  if (millis() - lastDbgLoop > 5000) {
-    if (IsRunning()) {
-      Serial.printf("[Pump::loop] pin=%d RUNNING: UpTime=%lums (%lus) millis=%lu delta=%lu\r\n",
-        GetPinNumber(), UpTime, UpTime / 1000, millis(), millis() - LastLoopMillis);
-    } else if (UpTime > 0) {
-      Serial.printf("[Pump::loop] pin=%d STOPPED: UpTime=%lums (%lus) millis=%lu\r\n",
-        GetPinNumber(), UpTime, UpTime / 1000, millis());
-    }
-    lastDbgLoop = millis();
-  }
-#endif
-
   // Call the loop handler if it exists, if the pump is not running
   // and only if the interlock pump is running (if it exists)
   if (interlock_pump_ == nullptr || (interlock_pump_ != nullptr && interlock_pump_->IsEnabled())) {

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -97,11 +97,11 @@ u_int8_t Pump::Start(bool _resetUpTime)
     }
   }
 #ifdef KC868_A8
-  else if (bitMaskErrors != 0) {
-    // Only log if there are actual error conditions (not just "already running")
+  else if (bitMaskErrors != 0 && bitMaskErrors != lastBitMaskErrors) {
     Serial.printf("[Pump::Start] pin=%d -> BLOCKED: UpTimeErr=%d Tank=%d Interlock=%d\r\n",
       GetPinNumber(), (int)UpTimeError, (int)TankLevel(), (int)CheckInterlock());
   }
+  lastBitMaskErrors = bitMaskErrors;
 #endif
   return bitMaskErrors;
 }

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -60,7 +60,7 @@ void Pump::loop()
     if(!TankLevel())
     {
       Stop();
-    } 
+    }
 
     // If there is an interlock pump and it stopped. Stop this pump as well
     if ((interlock_pump_!=nullptr) && (interlock_pump_->IsEnabled() == false))
@@ -91,6 +91,11 @@ u_int8_t Pump::Start(bool _resetUpTime)
 
   if((!IsRunning()) && !UpTimeError && TankLevel() && CheckInterlock())
   {
+    // CRITICAL: Set LastLoopMillis BEFORE Enable() to prevent race condition.
+    // On dual-core ESP32, Pump::loop() on the other core can read stale
+    // LastLoopMillis=0 during the I2C Enable() call, causing UpTime to
+    // jump by the entire board uptime in a single iteration.
+    LastLoopMillis = millis();
     if (!this->Relay::Enable()) {
       bitMaskErrors |= (1 << 3); // Bit 3: Relay error
 #ifdef KC868_A8
@@ -99,7 +104,7 @@ u_int8_t Pump::Start(bool _resetUpTime)
 #endif
       return bitMaskErrors;
     } else {
-      LastLoopMillis = StartTime = millis();
+      StartTime = millis();
 #ifdef KC868_A8
       Serial.printf("[Pump::Start] pin=%d -> OK: UpTime=%lums millis=%lu\r\n",
         GetPinNumber(), UpTime, millis());
@@ -164,7 +169,7 @@ bool Pump::TankLevel()
   }
   else if (tank_level_pin == NO_LEVEL)
   {
-    return (GetTankFill() > 5.); //alert below 5% 
+    return (GetTankFill() > 5.); //alert below 5%
   }
   else
   {
@@ -178,7 +183,7 @@ bool Pump::TankLevel()
     }
 #endif
     return (digitalRead(tank_level_pin) == TANK_FULL);
-  } 
+  }
 }
 
 //Set tank fill (percentage of tank volume)
@@ -201,7 +206,7 @@ void Pump::SetTankVolume(double _tankvolume)
 }
 
 //Return the percentage used since last reset of UpTime
-double Pump::GetTankUsage() 
+double Pump::GetTankUsage()
 {
   float PercentageUsed = -1.0;
   if((tankvolume != 0.0) && (flowrate !=0.0))
@@ -210,7 +215,7 @@ double Pump::GetTankUsage()
     double Consumption = flowrate/60.0*MinutesOfUpTime;
     PercentageUsed = Consumption/tankvolume*100.0;
   }
-  return (PercentageUsed); 
+  return (PercentageUsed);
 }
 
 //Set flow rate of the pump in Liters/hour
@@ -228,7 +233,7 @@ void Pump::SetMaxUpTime(unsigned long _maxuptime)
   CurrMaxUpTime = _maxuptime;
 }
 
-//Set a minimum running time (in millisecs) 
+//Set a minimum running time (in millisecs)
 //Pump can't stop before this time is reached
 //Set "Min" to 0 to disable limit
 void Pump::SetMinUpTime(unsigned long _minuptime)
@@ -274,7 +279,7 @@ void Pump::SetInterlock(uint8_t _interlock_pin_id)
   interlock_pin_id = _interlock_pin_id;
 }
 
-uint8_t Pump::GetInterlockId(void) 
+uint8_t Pump::GetInterlockId(void)
 {
 /*  if(interlock_pump_ != nullptr)
   {
@@ -308,22 +313,22 @@ void Pump::SavePreferences(Preferences& prefs, uint8_t pin_id)  {
 
     snprintf(key, sizeof(key), "d%d_fr", pin_id);  // "device_X_flowrate"
     prefs.putDouble(key, flowrate);
-  
+
     snprintf(key, sizeof(key), "d%d_tv", pin_id);  // "device_X_tankvolume"
     prefs.putDouble(key, tankvolume);
-  
+
     snprintf(key, sizeof(key), "d%d_tf", pin_id);  // "device_X_tankfill"
     prefs.putDouble(key, tankfill);
-  
+
     snprintf(key, sizeof(key), "d%d_tl", pin_id);  // "device_X_tanklevelpin"
     prefs.putUChar(key, tank_level_pin);
-  
+
     snprintf(key, sizeof(key), "d%d_il", pin_id);  // "device_X_interlockid"
     prefs.putUChar(key, interlock_pin_id);
-  
+
     snprintf(key, sizeof(key), "d%d_mu", pin_id);  // "device_X_maxutime"
     prefs.putULong(key, MaxUpTime);
-  
+
     snprintf(key, sizeof(key), "d%d_mi", pin_id);  // "device_X_minutime"
     prefs.putULong(key, MinUpTime);
   }

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -9,6 +9,22 @@
 void Pump::loop()
 {
   u_int8_t bitMaskErrors = 0;
+
+#ifdef KC868_A8
+  // Periodic debug output (every 5s) to track UpTime accumulation
+  static unsigned long lastDbgLoop = 0;
+  if (millis() - lastDbgLoop > 5000) {
+    if (IsRunning()) {
+      Serial.printf("[Pump::loop] pin=%d RUNNING: UpTime=%lums (%lus) millis=%lu delta=%lu\r\n",
+        GetPinNumber(), UpTime, UpTime / 1000, millis(), millis() - LastLoopMillis);
+    } else if (UpTime > 0) {
+      Serial.printf("[Pump::loop] pin=%d STOPPED: UpTime=%lums (%lus) millis=%lu\r\n",
+        GetPinNumber(), UpTime, UpTime / 1000, millis());
+    }
+    lastDbgLoop = millis();
+  }
+#endif
+
   // Call the loop handler if it exists, if the pump is not running
   // and only if the interlock pump is running (if it exists)
   if (interlock_pump_ == nullptr || (interlock_pump_ != nullptr && interlock_pump_->IsEnabled())) {
@@ -68,33 +84,69 @@ u_int8_t Pump::Start(bool _resetUpTime)
   bitMaskErrors |= (!TankLevel() & 1) << 1; // Bit 1: Tank level error
   bitMaskErrors |= (!CheckInterlock() & 1) << 2; // Bit 2: Interlock error
 
+#ifdef KC868_A8
+  Serial.printf("[Pump::Start] pin=%d ENTERED: IsRunning=%d UpTime=%lums (%lus) millis=%lu bits=0x%02X\r\n",
+    GetPinNumber(), (int)IsRunning(), UpTime, UpTime / 1000, millis(), bitMaskErrors);
+#endif
+
   if((!IsRunning()) && !UpTimeError && TankLevel() && CheckInterlock())
   {
     if (!this->Relay::Enable()) {
       bitMaskErrors |= (1 << 3); // Bit 3: Relay error
+#ifdef KC868_A8
+      Serial.printf("[Pump::Start] pin=%d Relay Enable FAILED! bits=0x%02X\r\n",
+        GetPinNumber(), bitMaskErrors);
+#endif
       return bitMaskErrors;
     } else {
-      LastLoopMillis = StartTime = millis(); 
+      LastLoopMillis = StartTime = millis();
+#ifdef KC868_A8
+      Serial.printf("[Pump::Start] pin=%d -> OK: UpTime=%lums millis=%lu\r\n",
+        GetPinNumber(), UpTime, millis());
+#endif
     }
   }
+#ifdef KC868_A8
+  else {
+    Serial.printf("[Pump::Start] pin=%d -> SKIPPED: IsRunning=%d UpTimeErr=%d Tank=%d Interlock=%d\r\n",
+      GetPinNumber(), (int)IsRunning(), (int)UpTimeError, (int)TankLevel(), (int)CheckInterlock());
+  }
+#endif
   return bitMaskErrors;
 }
 
 //Switch pump OFF
 bool Pump::Stop()
 {
+#ifdef KC868_A8
+  Serial.printf("[Pump::Stop]  pin=%d ENTERED: IsRunning=%d UpTime=%lums (%lus) millis=%lu\r\n",
+    GetPinNumber(), (int)IsRunning(), UpTime, UpTime / 1000, millis());
+#endif
   if(IsRunning())
   {
     if (!this->Relay::Disable())
     {
+#ifdef KC868_A8
+      Serial.printf("[Pump::Stop]  pin=%d -> Relay Disable FAILED!\r\n", GetPinNumber());
+#endif
       return false;
     }
-    
-    UpTime += millis() - LastLoopMillis; 
 
-    
+    unsigned long delta = millis() - LastLoopMillis;
+    UpTime += delta;
+
+#ifdef KC868_A8
+    Serial.printf("[Pump::Stop]  pin=%d -> OK: delta=%lums UpTime=%lums (%lus)\r\n",
+      GetPinNumber(), delta, UpTime, UpTime / 1000);
+#endif
     return true;
-  } else return false;
+  }
+#ifdef KC868_A8
+  else {
+    Serial.printf("[Pump::Stop]  pin=%d -> SKIPPED (not running)\r\n", GetPinNumber());
+  }
+#endif
+  return false;
 }
 
 //Pump status

--- a/lib/Pump-master/src/Pump.cpp
+++ b/lib/Pump-master/src/Pump.cpp
@@ -84,11 +84,6 @@ u_int8_t Pump::Start(bool _resetUpTime)
   bitMaskErrors |= (!TankLevel() & 1) << 1; // Bit 1: Tank level error
   bitMaskErrors |= (!CheckInterlock() & 1) << 2; // Bit 2: Interlock error
 
-#ifdef KC868_A8
-  Serial.printf("[Pump::Start] pin=%d ENTERED: IsRunning=%d UpTime=%lums (%lus) millis=%lu bits=0x%02X\r\n",
-    GetPinNumber(), (int)IsRunning(), UpTime, UpTime / 1000, millis(), bitMaskErrors);
-#endif
-
   // [FIX-A] Always update LastLoopMillis BEFORE checking relay state.
   // Previously, this was inside the if(!IsRunning()) block, which meant
   // LastLoopMillis stayed at 0 (from constructor or ResetUpTime) when:
@@ -117,9 +112,10 @@ u_int8_t Pump::Start(bool _resetUpTime)
     }
   }
 #ifdef KC868_A8
-  else {
-    Serial.printf("[Pump::Start] pin=%d -> SKIPPED: IsRunning=%d UpTimeErr=%d Tank=%d Interlock=%d\r\n",
-      GetPinNumber(), (int)IsRunning(), (int)UpTimeError, (int)TankLevel(), (int)CheckInterlock());
+  else if (bitMaskErrors != 0) {
+    // Only log if there are actual error conditions (not just "already running")
+    Serial.printf("[Pump::Start] pin=%d -> BLOCKED: UpTimeErr=%d Tank=%d Interlock=%d\r\n",
+      GetPinNumber(), (int)UpTimeError, (int)TankLevel(), (int)CheckInterlock());
   }
 #endif
   return bitMaskErrors;
@@ -128,10 +124,6 @@ u_int8_t Pump::Start(bool _resetUpTime)
 //Switch pump OFF
 bool Pump::Stop()
 {
-#ifdef KC868_A8
-  Serial.printf("[Pump::Stop]  pin=%d ENTERED: IsRunning=%d UpTime=%lums (%lus) millis=%lu\r\n",
-    GetPinNumber(), (int)IsRunning(), UpTime, UpTime / 1000, millis());
-#endif
   if(IsRunning())
   {
     if (!this->Relay::Disable())
@@ -151,11 +143,6 @@ bool Pump::Stop()
 #endif
     return true;
   }
-#ifdef KC868_A8
-  else {
-    Serial.printf("[Pump::Stop]  pin=%d -> SKIPPED (not running)\r\n", GetPinNumber());
-  }
-#endif
   return false;
 }
 

--- a/lib/Pump-master/src/Pump.h
+++ b/lib/Pump-master/src/Pump.h
@@ -99,6 +99,7 @@ class Pump : public Relay {
     PIN*  interlock_pump_     = nullptr; // Interlock can be passed 
     uint8_t interlock_pin_id  = NO_INTERLOCK; // Used temporarily to store the interlock pin id but converted in pointer by InitInterlock function
     unsigned long LastLoopMillis     = 0;
+    uint8_t lastBitMaskErrors        = 0; // Track previous Start() error state for change-only logging
     uint8_t tank_level_pin;
     double flowrate, tankvolume, tankfill; // Flowrate in L/h, tank volume in Liters, tank fill in %
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,7 @@ lib_deps =
 	rlogiacco/CircularBuffer@^1.4.0
 	yiannisbourkelis/Uptime Library@^1.0.0
 board_build.partitions = min_spiffs.csv
+extra_scripts = pre:scripts/build_flags.py
 
 ; ============================================================
 ; KC868-A8 Environment (default)

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = kc868_a8
+default_envs = KC868_A8
 
 ; ============================================================
 ; Common settings for all environments
@@ -41,7 +41,7 @@ board_build.partitions = min_spiffs.csv
 ; KC868-A8 Environment (default)
 ; Hardware: ESP32 + PCF8574 I2C relays + inputs
 ; ============================================================
-[env:kc868_a8]
+[env:KC868_A8]
 board = esp32dev
 build_flags = 
 	-D KC868_A8
@@ -66,14 +66,14 @@ upload_port = COM4
 ; Serial Upload (for KC868-A8)
 ; ============================================================
 [env:serial_upload]
-extends = env:kc868_a8
+extends = env:KC868_A8
 upload_protocol = esptool
 
 ; ============================================================
 ; OTA Upload
 ; ============================================================
 [env:OTA_upload]
-extends = env:kc868_a8
+extends = env:KC868_A8
 upload_protocol = espota
 upload_port = 192.168.1.45
 upload_flags = 

--- a/scripts/build_flags.py
+++ b/scripts/build_flags.py
@@ -1,0 +1,20 @@
+"""Pre-build script: inject git commit hash as compile-time define."""
+import subprocess
+
+Import("env")
+
+try:
+    git_hash = subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"],
+        stderr=subprocess.DEVNULL
+    ).decode("ascii").strip()
+    dirty = subprocess.check_output(
+        ["git", "diff", "--quiet"],
+        stderr=subprocess.DEVNULL
+    ).returncode != 0
+    git_version = git_hash + ("-dirty" if dirty else "")
+except Exception:
+    git_version = "unknown"
+
+env.Append(BUILD_FLAGS=[f'-D GIT_COMMIT_HASH=\\"{git_version}\\"'])
+print(f"[build_flags] GIT_COMMIT_HASH = {git_version}")

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -345,12 +345,31 @@ void pHRegulation(void *pvParameters)
            turn the Acid pump on/off based on pid output
           ************************************************/
           unsigned long now = millis();
-          if (now - PMData.PhPIDwStart > PMConfig.get<unsigned long>(PHPIDWINDOWSIZE))
+          unsigned long windowSize = PMConfig.get<unsigned long>(PHPIDWINDOWSIZE);
+          unsigned long elapsed = now - PMData.PhPIDwStart;
+          bool windowShifted = false;
+
+          if (elapsed > windowSize)
           {
             //time to shift the Relay Window
             PMData.PhPIDwStart += PMConfig.get<double>(PHPIDWINDOWSIZE);
-            }
-          if ((unsigned long)PMData.PhPIDOutput <= now - PMData.PhPIDwStart)
+            elapsed = now - PMData.PhPIDwStart;
+            windowShifted = true;
+          }
+
+          bool shouldRun = ((unsigned long)PMData.PhPIDOutput > elapsed);
+
+          // Debug: log pump state before Start/Stop decision
+          Debug.print(DBG_INFO,
+            "[pH-Window] Out=%6lu Elapsed=%6lu Win=%lu Shift=%d ShouldRun=%d "
+            "Running=%d UpTimeErr=%d Tank=%d Interlock=%d UpTime=%lu MaxUp=%lu",
+            (unsigned long)PMData.PhPIDOutput, elapsed, windowSize,
+            (int)windowShifted, (int)shouldRun,
+            (int)PhPump.IsRunning(), (int)PhPump.UpTimeError,
+            (int)PhPump.TankLevel(), (int)PhPump.CheckInterlock(),
+            PhPump.UpTime, PhPump.CurrMaxUpTime);
+
+          if (!shouldRun)
             PhPump.Stop();
           else
             PhPump.Start();   
@@ -417,12 +436,31 @@ void OrpRegulation(void *pvParameters)
          turn the Chl pump on/off based on pid output
         ************************************************/
         unsigned long now = millis();
-        if (now - PMData.OrpPIDwStart > PMConfig.get<double>(ORPPIDWINDOWSIZE))
+        unsigned long windowSize = PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE);
+        unsigned long elapsed = now - PMData.OrpPIDwStart;
+        bool windowShifted = false;
+
+        if (elapsed > windowSize)
         {
           //time to shift the Relay Window
           PMData.OrpPIDwStart += PMConfig.get<double>(ORPPIDWINDOWSIZE);
+          elapsed = now - PMData.OrpPIDwStart;
+          windowShifted = true;
         }
-        if ((unsigned long)PMData.OrpPIDOutput <= now - PMData.OrpPIDwStart)
+
+        bool shouldRun = ((unsigned long)PMData.OrpPIDOutput > elapsed);
+
+        // Debug: log pump state before Start/Stop decision
+        Debug.print(DBG_INFO,
+          "[ORP-Window] Out=%6lu Elapsed=%6lu Win=%lu Shift=%d ShouldRun=%d "
+          "Running=%d UpTimeErr=%d Tank=%d Interlock=%d UpTime=%lu MaxUp=%lu",
+          (unsigned long)PMData.OrpPIDOutput, elapsed, windowSize,
+          (int)windowShifted, (int)shouldRun,
+          (int)ChlPump.IsRunning(), (int)ChlPump.UpTimeError,
+          (int)ChlPump.TankLevel(), (int)ChlPump.CheckInterlock(),
+          ChlPump.UpTime, ChlPump.CurrMaxUpTime);
+
+        if (!shouldRun)
           ChlPump.Stop();
         else
           ChlPump.Start();

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -409,8 +409,17 @@ void pHRegulation(void *pvParameters)
 
           if (!shouldRun)
             PhPump.Stop();
-          else
-            PhPump.Start();   
+          else {
+            Debug.print(DBG_INFO,
+              "[pH-Start] Out=%lu Elapsed=%lu Win=%lu Shift=%d "
+              "Run=%d UpErr=%d Tank=%d Ilk=%d Up=%lu Max=%lu",
+              (unsigned long)PMData.PhPIDOutput, elapsed, windowSize,
+              (int)windowShifted,
+              (int)PhPump.IsRunning(), (int)PhPump.UpTimeError,
+              (int)PhPump.TankLevel(), (int)PhPump.CheckInterlock(),
+              PhPump.UpTime, PhPump.CurrMaxUpTime);
+            PhPump.Start();
+          }
       } else {
         PhPID.SetMode(MANUAL);
         PMData.Ph_RegOnOff = false;
@@ -526,8 +535,17 @@ void OrpRegulation(void *pvParameters)
 
         if (!shouldRun)
           ChlPump.Stop();
-        else
+        else {
+          Debug.print(DBG_INFO,
+            "[ORP-Start] Out=%lu Elapsed=%lu Win=%lu Shift=%d "
+            "Run=%d UpErr=%d Tank=%d Ilk=%d Up=%lu Max=%lu",
+            (unsigned long)PMData.OrpPIDOutput, elapsed, windowSize,
+            (int)windowShifted,
+            (int)ChlPump.IsRunning(), (int)ChlPump.UpTimeError,
+            (int)ChlPump.TankLevel(), (int)ChlPump.CheckInterlock(),
+            ChlPump.UpTime, ChlPump.CurrMaxUpTime);
           ChlPump.Start();
+        }
       } else {
         OrpPID.SetMode(MANUAL);
         PMData.Orp_RegOnOff = false;

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -350,6 +350,21 @@ void pHRegulation(void *pvParameters)
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f, %13.9f, %13.9f, %17.9f",PMData.PhPIDOutput,PMData.PhValue,PMData.Ph_SetPoint,PMConfig.get<double>(PH_KP));
             if(PMData.PhPIDOutput < (double)30000.) PMData.PhPIDOutput = 0.;
             Debug.print(DBG_INFO,"Ph  regulation: %10.2f",PMData.PhPIDOutput);
+
+            // Window state at compute time
+            unsigned long now_dbg = millis();
+            unsigned long win_dbg = PMConfig.get<unsigned long>(PHPIDWINDOWSIZE);
+            unsigned long el_dbg = now_dbg - PMData.PhPIDwStart;
+            bool shifted_dbg = (el_dbg > win_dbg);
+            bool should_dbg = ((unsigned long)PMData.PhPIDOutput > (shifted_dbg ? 0 : el_dbg));
+            Debug.print(DBG_INFO,
+              "[pH-Win] Out=%lu El=%lu Win=%lu Shift=%d ShouldRun=%d "
+              "Run=%d UpErr=%d Tank=%d Ilk=%d Up=%lu Max=%lu",
+              (unsigned long)PMData.PhPIDOutput, el_dbg, win_dbg,
+              (int)shifted_dbg, (int)should_dbg,
+              (int)PhPump.IsRunning(), (int)PhPump.UpTimeError,
+              (int)PhPump.TankLevel(), (int)PhPump.CheckInterlock(),
+              PhPump.UpTime, PhPump.CurrMaxUpTime);
           }    
           /************************************************
            turn the Acid pump on/off based on pid output
@@ -454,6 +469,21 @@ void OrpRegulation(void *pvParameters)
           Debug.print(DBG_INFO,"ORP regulation: %10.2f, %13.9f, %12.9f, %17.9f",PMData.OrpPIDOutput,PMData.OrpValue,PMData.Orp_SetPoint,PMConfig.get<double>(ORP_KP));
           if(PMData.OrpPIDOutput < (double)30000.) PMData.OrpPIDOutput = 0.;    
             Debug.print(DBG_INFO,"Orp regulation: %10.2f",PMData.OrpPIDOutput);
+
+            // Window state at compute time
+            unsigned long now_dbg2 = millis();
+            unsigned long win_dbg2 = PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE);
+            unsigned long el_dbg2 = now_dbg2 - PMData.OrpPIDwStart;
+            bool shifted_dbg2 = (el_dbg2 > win_dbg2);
+            bool should_dbg2 = ((unsigned long)PMData.OrpPIDOutput > (shifted_dbg2 ? 0 : el_dbg2));
+            Debug.print(DBG_INFO,
+              "[ORP-Win] Out=%lu El=%lu Win=%lu Shift=%d ShouldRun=%d "
+              "Run=%d UpErr=%d Tank=%d Ilk=%d Up=%lu Max=%lu",
+              (unsigned long)PMData.OrpPIDOutput, el_dbg2, win_dbg2,
+              (int)shifted_dbg2, (int)should_dbg2,
+              (int)ChlPump.IsRunning(), (int)ChlPump.UpTimeError,
+              (int)ChlPump.TankLevel(), (int)ChlPump.CheckInterlock(),
+              ChlPump.UpTime, ChlPump.CurrMaxUpTime);
           }    
         /************************************************
          turn the Chl pump on/off based on pid output

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -330,6 +330,16 @@ void pHRegulation(void *pvParameters)
     td = millis();
     #endif 
 
+    // [DEBUG-TMP] Heartbeat to verify pH task runs
+    static unsigned long phLastDbg = 0;
+    if (millis() - phLastDbg > 30000) {
+      phLastDbg = millis();
+      Debug.print(DBG_INFO,
+        "[pH-Task] alive mode=%d filtRun=%d Output=%.0f wStart=%lu",
+        (int)PhPID.GetMode(), (int)FiltrationPump.IsRunning(),
+        PMData.PhPIDOutput, (unsigned long)PMData.PhPIDwStart);
+    }
+
     //do not compute PID if filtration pump is not running
     // Set also a lower limit at 30s (a lower pump duration doesn't mean anything)
     if (PhPID.GetMode() == AUTOMATIC)

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -359,15 +359,20 @@ void pHRegulation(void *pvParameters)
 
           bool shouldRun = ((unsigned long)PMData.PhPIDOutput > elapsed);
 
-          // Debug: log pump state before Start/Stop decision
-          Debug.print(DBG_INFO,
-            "[pH-Window] Out=%6lu Elapsed=%6lu Win=%lu Shift=%d ShouldRun=%d "
-            "Running=%d UpTimeErr=%d Tank=%d Interlock=%d UpTime=%lu MaxUp=%lu",
-            (unsigned long)PMData.PhPIDOutput, elapsed, windowSize,
-            (int)windowShifted, (int)shouldRun,
-            (int)PhPump.IsRunning(), (int)PhPump.UpTimeError,
-            (int)PhPump.TankLevel(), (int)PhPump.CheckInterlock(),
-            PhPump.UpTime, PhPump.CurrMaxUpTime);
+          // Debug: log only when PID wants to start the pump
+          static bool phLastShouldRun = false;
+          if (shouldRun && !phLastShouldRun)
+          {
+            Debug.print(DBG_INFO,
+              "[pH-Window] START Out=%6lu Elapsed=%6lu Win=%lu Shift=%d "
+              "Running=%d UpTimeErr=%d Tank=%d Interlock=%d UpTime=%lu MaxUp=%lu",
+              (unsigned long)PMData.PhPIDOutput, elapsed, windowSize,
+              (int)windowShifted,
+              (int)PhPump.IsRunning(), (int)PhPump.UpTimeError,
+              (int)PhPump.TankLevel(), (int)PhPump.CheckInterlock(),
+              PhPump.UpTime, PhPump.CurrMaxUpTime);
+          }
+          phLastShouldRun = shouldRun;
 
           if (!shouldRun)
             PhPump.Stop();
@@ -450,15 +455,20 @@ void OrpRegulation(void *pvParameters)
 
         bool shouldRun = ((unsigned long)PMData.OrpPIDOutput > elapsed);
 
-        // Debug: log pump state before Start/Stop decision
-        Debug.print(DBG_INFO,
-          "[ORP-Window] Out=%6lu Elapsed=%6lu Win=%lu Shift=%d ShouldRun=%d "
-          "Running=%d UpTimeErr=%d Tank=%d Interlock=%d UpTime=%lu MaxUp=%lu",
-          (unsigned long)PMData.OrpPIDOutput, elapsed, windowSize,
-          (int)windowShifted, (int)shouldRun,
-          (int)ChlPump.IsRunning(), (int)ChlPump.UpTimeError,
-          (int)ChlPump.TankLevel(), (int)ChlPump.CheckInterlock(),
-          ChlPump.UpTime, ChlPump.CurrMaxUpTime);
+        // Debug: log only when PID wants to start the pump
+        static bool orpLastShouldRun = false;
+        if (shouldRun && !orpLastShouldRun)
+        {
+          Debug.print(DBG_INFO,
+            "[ORP-Window] START Out=%6lu Elapsed=%6lu Win=%lu Shift=%d "
+            "Running=%d UpTimeErr=%d Tank=%d Interlock=%d UpTime=%lu MaxUp=%lu",
+            (unsigned long)PMData.OrpPIDOutput, elapsed, windowSize,
+            (int)windowShifted,
+            (int)ChlPump.IsRunning(), (int)ChlPump.UpTimeError,
+            (int)ChlPump.TankLevel(), (int)ChlPump.CheckInterlock(),
+            ChlPump.UpTime, ChlPump.CurrMaxUpTime);
+        }
+        orpLastShouldRun = shouldRun;
 
         if (!shouldRun)
           ChlPump.Stop();

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -209,6 +209,8 @@ void AnalogPoll(void *pvParameters)
         if (!isnan(simPSI)) PMData.PSIValue = simPSI;
 #endif
 
+
+
         Debug.print(DBG_DEBUG,"pH: %5.0f - %4.2f - ORP: %5.0f - %3.0fmV - PSI: %5.0f - %4.2fBar\r",
             ph_sensor_value,PMData.PhValue,orp_sensor_value,PMData.OrpValue,psi_sensor_value,PMData.PSIValue);
     }
@@ -375,7 +377,7 @@ void pHRegulation(void *pvParameters)
           if (elapsed > windowSize)
           {
             //time to shift the Relay Window
-            PMData.PhPIDwStart += PMConfig.get<double>(PHPIDWINDOWSIZE);
+            PMData.PhPIDwStart += PMConfig.get<unsigned long>(PHPIDWINDOWSIZE);
             elapsed = now - PMData.PhPIDwStart;
             windowShifted = true;
           }
@@ -493,7 +495,7 @@ void OrpRegulation(void *pvParameters)
         if (elapsed > windowSize)
         {
           //time to shift the Relay Window
-          PMData.OrpPIDwStart += PMConfig.get<double>(ORPPIDWINDOWSIZE);
+          PMData.OrpPIDwStart += PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE);
           elapsed = now - PMData.OrpPIDwStart;
           windowShifted = true;
         }

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -396,9 +396,8 @@ void pHRegulation(void *pvParameters)
 
           if (windowShifted)
           {
-            // New window: reset pump uptime safety limit so the pump
-            // can run again within this window.
-            PhPump.ResetUpTime();
+            // New window: clear any UpTimeError so the pump
+            // can run again within this window (daily total resets at midnight).
             PhPump.ClearErrors();
           }
 
@@ -514,7 +513,7 @@ void OrpRegulation(void *pvParameters)
 
         if (windowShifted)
         {
-          ChlPump.ResetUpTime();
+          // Clear any UpTimeError for new window (daily total resets at midnight).
           ChlPump.ClearErrors();
         }
 

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -209,8 +209,6 @@ void AnalogPoll(void *pvParameters)
         if (!isnan(simPSI)) PMData.PSIValue = simPSI;
 #endif
 
-
-
         Debug.print(DBG_DEBUG,"pH: %5.0f - %4.2f - ORP: %5.0f - %3.0fmV - PSI: %5.0f - %4.2fBar\r",
             ph_sensor_value,PMData.PhValue,orp_sensor_value,PMData.OrpValue,psi_sensor_value,PMData.PSIValue);
     }
@@ -384,20 +382,15 @@ void pHRegulation(void *pvParameters)
 
           bool shouldRun = ((unsigned long)PMData.PhPIDOutput > elapsed);
 
-          // Debug: log only on transition to "PID wants to start"
-          static bool phLastShouldRun = false;
-          if (shouldRun && !phLastShouldRun)
-          {
-            Debug.print(DBG_INFO,
-              "[pH-Window] START Out=%6lu Elapsed=%6lu Win=%lu Shift=%d "
-              "Running=%d UpTimeErr=%d Tank=%d Interlock=%d UpTime=%lu MaxUp=%lu",
-              (unsigned long)PMData.PhPIDOutput, elapsed, windowSize,
-              (int)windowShifted,
-              (int)PhPump.IsRunning(), (int)PhPump.UpTimeError,
-              (int)PhPump.TankLevel(), (int)PhPump.CheckInterlock(),
-              PhPump.UpTime, PhPump.CurrMaxUpTime);
-          }
-          phLastShouldRun = shouldRun;
+          // SERIAL-DEBUG: always log the decision state (bypass Debug class)
+          Serial.printf("[pH-Decide] Output=%lu Elapsed=%lu Win=%lu Shift=%d "
+                        "shouldRun=%d Run=%d UpErr=%d Tank=%d Ilk=%d Up=%lu\r\n",
+                        (unsigned long)PMData.PhPIDOutput, elapsed, windowSize,
+                        (int)windowShifted, (int)shouldRun,
+                        (int)PhPump.IsRunning(), (int)PhPump.UpTimeError,
+                        (int)PhPump.TankLevel(), (int)PhPump.CheckInterlock(),
+                        PhPump.UpTime);
+          Serial.flush();
 
           if (windowShifted)
           {
@@ -410,14 +403,9 @@ void pHRegulation(void *pvParameters)
           if (!shouldRun)
             PhPump.Stop();
           else {
-            Debug.print(DBG_INFO,
-              "[pH-Start] Out=%lu Elapsed=%lu Win=%lu Shift=%d "
-              "Run=%d UpErr=%d Tank=%d Ilk=%d Up=%lu Max=%lu",
-              (unsigned long)PMData.PhPIDOutput, elapsed, windowSize,
-              (int)windowShifted,
-              (int)PhPump.IsRunning(), (int)PhPump.UpTimeError,
-              (int)PhPump.TankLevel(), (int)PhPump.CheckInterlock(),
-              PhPump.UpTime, PhPump.CurrMaxUpTime);
+            Serial.printf("[pH-Start] GO! Output=%lu Elapsed=%lu\r\n",
+                          (unsigned long)PMData.PhPIDOutput, elapsed);
+            Serial.flush();
             PhPump.Start();
           }
       } else {
@@ -512,20 +500,15 @@ void OrpRegulation(void *pvParameters)
 
         bool shouldRun = ((unsigned long)PMData.OrpPIDOutput > elapsed);
 
-        // Debug: log only on transition to "PID wants to start"
-        static bool orpLastShouldRun = false;
-        if (shouldRun && !orpLastShouldRun)
-        {
-          Debug.print(DBG_INFO,
-            "[ORP-Window] START Out=%6lu Elapsed=%6lu Win=%lu Shift=%d "
-            "Running=%d UpTimeErr=%d Tank=%d Interlock=%d UpTime=%lu MaxUp=%lu",
-            (unsigned long)PMData.OrpPIDOutput, elapsed, windowSize,
-            (int)windowShifted,
-            (int)ChlPump.IsRunning(), (int)ChlPump.UpTimeError,
-            (int)ChlPump.TankLevel(), (int)ChlPump.CheckInterlock(),
-            ChlPump.UpTime, ChlPump.CurrMaxUpTime);
-        }
-        orpLastShouldRun = shouldRun;
+        // SERIAL-DEBUG: always log the decision state (bypass Debug class)
+        Serial.printf("[ORP-Decide] Output=%lu Elapsed=%lu Win=%lu Shift=%d "
+                      "shouldRun=%d Run=%d UpErr=%d Tank=%d Ilk=%d Up=%lu\r\n",
+                      (unsigned long)PMData.OrpPIDOutput, elapsed, windowSize,
+                      (int)windowShifted, (int)shouldRun,
+                      (int)ChlPump.IsRunning(), (int)ChlPump.UpTimeError,
+                      (int)ChlPump.TankLevel(), (int)ChlPump.CheckInterlock(),
+                      ChlPump.UpTime);
+        Serial.flush();
 
         if (windowShifted)
         {
@@ -536,14 +519,9 @@ void OrpRegulation(void *pvParameters)
         if (!shouldRun)
           ChlPump.Stop();
         else {
-          Debug.print(DBG_INFO,
-            "[ORP-Start] Out=%lu Elapsed=%lu Win=%lu Shift=%d "
-            "Run=%d UpErr=%d Tank=%d Ilk=%d Up=%lu Max=%lu",
-            (unsigned long)PMData.OrpPIDOutput, elapsed, windowSize,
-            (int)windowShifted,
-            (int)ChlPump.IsRunning(), (int)ChlPump.UpTimeError,
-            (int)ChlPump.TankLevel(), (int)ChlPump.CheckInterlock(),
-            ChlPump.UpTime, ChlPump.CurrMaxUpTime);
+          Serial.printf("[ORP-Start] GO! Output=%lu Elapsed=%lu\r\n",
+                        (unsigned long)PMData.OrpPIDOutput, elapsed);
+          Serial.flush();
           ChlPump.Start();
         }
       } else {

--- a/src/Loops.cpp
+++ b/src/Loops.cpp
@@ -359,7 +359,7 @@ void pHRegulation(void *pvParameters)
 
           bool shouldRun = ((unsigned long)PMData.PhPIDOutput > elapsed);
 
-          // Debug: log only when PID wants to start the pump
+          // Debug: log only on transition to "PID wants to start"
           static bool phLastShouldRun = false;
           if (shouldRun && !phLastShouldRun)
           {
@@ -373,6 +373,14 @@ void pHRegulation(void *pvParameters)
               PhPump.UpTime, PhPump.CurrMaxUpTime);
           }
           phLastShouldRun = shouldRun;
+
+          if (windowShifted)
+          {
+            // New window: reset pump uptime safety limit so the pump
+            // can run again within this window.
+            PhPump.ResetUpTime();
+            PhPump.ClearErrors();
+          }
 
           if (!shouldRun)
             PhPump.Stop();
@@ -455,7 +463,7 @@ void OrpRegulation(void *pvParameters)
 
         bool shouldRun = ((unsigned long)PMData.OrpPIDOutput > elapsed);
 
-        // Debug: log only when PID wants to start the pump
+        // Debug: log only on transition to "PID wants to start"
         static bool orpLastShouldRun = false;
         if (shouldRun && !orpLastShouldRun)
         {
@@ -469,6 +477,12 @@ void OrpRegulation(void *pvParameters)
             ChlPump.UpTime, ChlPump.CurrMaxUpTime);
         }
         orpLastShouldRun = shouldRun;
+
+        if (windowShifted)
+        {
+          ChlPump.ResetUpTime();
+          ChlPump.ClearErrors();
+        }
 
         if (!shouldRun)
           ChlPump.Stop();

--- a/src/PoolServer_Commands.cpp
+++ b/src/PoolServer_Commands.cpp
@@ -348,13 +348,13 @@ void p_PhPIDParams(StaticJsonDocument<250>  &_jsonsdoc) {
 }
 void p_OrpPIDWSize(StaticJsonDocument<250>  &_jsonsdoc) {
     PMConfig.put<unsigned long>(ORPPIDWINDOWSIZE, (unsigned long)_jsonsdoc[F("OrpPIDWSize")]*60*1000); //in millisecs
-    OrpPID.SetSampleTime((int)PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE));
+    OrpPID.SetSampleTime(30000);  // Fixed 30s compute interval, independent of window size
     OrpPID.SetOutputLimits(0, PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE));  //Whatever happens, don't allow continuous injection of Chl for more than a PID Window
     PublishSettings();
 }
 void p_PhPIDWSize(StaticJsonDocument<250>  &_jsonsdoc) {
     PMConfig.put<unsigned long>(PHPIDWINDOWSIZE, (unsigned long)_jsonsdoc[F("PhPIDWSize")]*60*1000); //in millisecs
-    PhPID.SetSampleTime((int)PMConfig.get<unsigned long>(PHPIDWINDOWSIZE));
+    PhPID.SetSampleTime(30000);  // Fixed 30s compute interval, independent of window size
     PhPID.SetOutputLimits(0, PMConfig.get<unsigned long>(PHPIDWINDOWSIZE));    //Whatever happens, don't allow continuous injection of Acid for more than a PID Window
     PublishSettings();
 }

--- a/src/SensorSimulation.cpp
+++ b/src/SensorSimulation.cpp
@@ -91,21 +91,12 @@ void SensorSimulation::updateAnalogSimulation() {
     bool phPumpOn = PhPump.IsRunning();
     bool chlPumpOn = ChlPump.IsRunning();
 
-    Debug.print(DBG_INFO, "[AnalogSim] PhPump: %s | ChlPump: %s",
-        phPumpOn ? "ON" : "OFF",
-        chlPumpOn ? "ON" : "OFF");
-
     // --- pH Simulation ---
     if (simulating_ph) {
-        double oldPH = sim_ph_value;
         if (phPumpOn) {
             sim_ph_value -= SIM_PH_ACTIVE_RATE;
-            Debug.print(DBG_INFO, "[Sim] pH: %.3f -> %.3f (pump ON, -%.3f)",
-                oldPH, sim_ph_value, SIM_PH_ACTIVE_RATE);
         } else {
             sim_ph_value += SIM_PH_DRIFT_RATE;
-            Debug.print(DBG_INFO, "[Sim] pH: %.3f -> %.3f (pump OFF, +%.3f)",
-                oldPH, sim_ph_value, SIM_PH_DRIFT_RATE);
         }
         if (sim_ph_value < SIM_PH_MIN) sim_ph_value = SIM_PH_MIN;
         if (sim_ph_value > SIM_PH_MAX) sim_ph_value = SIM_PH_MAX;
@@ -113,15 +104,10 @@ void SensorSimulation::updateAnalogSimulation() {
 
     // --- ORP Simulation ---
     if (simulating_orp) {
-        double oldORP = sim_orp_value;
         if (chlPumpOn) {
             sim_orp_value += SIM_ORP_ACTIVE_RATE;
-            Debug.print(DBG_INFO, "[Sim] ORP: %.1f -> %.1f (pump ON, +%.1f)",
-                oldORP, sim_orp_value, SIM_ORP_ACTIVE_RATE);
         } else {
             sim_orp_value -= SIM_ORP_DRIFT_RATE;
-            Debug.print(DBG_INFO, "[Sim] ORP: %.1f -> %.1f (pump OFF, -%.1f)",
-                oldORP, sim_orp_value, SIM_ORP_DRIFT_RATE);
         }
         if (sim_orp_value < SIM_ORP_MIN) sim_orp_value = SIM_ORP_MIN;
         if (sim_orp_value > SIM_ORP_MAX) sim_orp_value = SIM_ORP_MAX;

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -393,12 +393,12 @@ void setup()
   // Limit the PIDs output range in order to limit max. pumps runtime (safety first...)
   PhPID.SetTunings(PMConfig.get<double>(PH_KP), PMConfig.get<double>(PH_KI), PMConfig.get<double>(PH_KD));
   PhPID.SetControllerDirection(PhPID_DIRECTION);
-  PhPID.SetSampleTime((int)PMConfig.get<unsigned long>(PHPIDWINDOWSIZE));
+  PhPID.SetSampleTime(30000);   // Recompute every 30s (independent of window size)
   PhPID.SetOutputLimits(0, PMConfig.get<unsigned long>(PHPIDWINDOWSIZE));    //Whatever happens, don't allow continuous injection of Acid for more than a PID Window
 
   OrpPID.SetTunings(PMConfig.get<double>(ORP_KP), PMConfig.get<double>(ORP_KI), PMConfig.get<double>(ORP_KD));
   OrpPID.SetControllerDirection(OrpPID_DIRECTION);
-  OrpPID.SetSampleTime((int)PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE));
+  OrpPID.SetSampleTime(30000);  // Recompute every 30s (independent of window size)
   OrpPID.SetOutputLimits(0, PMConfig.get<unsigned long>(ORPPIDWINDOWSIZE));  //Whatever happens, don't allow continuous injection of Chl for more than a PID Window
 
   // PIDs off at start

--- a/src/Setup.cpp
+++ b/src/Setup.cpp
@@ -181,7 +181,7 @@ void setup()
 
   //get board info
   info();
-  Debug.print(DBG_INFO,"Booting PoolMaster Version: %s",FIRMW);
+  Debug.print(DBG_INFO,"Booting PoolMaster Version: %s [%s]",FIRMW,GIT_COMMIT_HASH);
   // Initialize Nextion TFT
   #ifdef TFT_CONNECTED
   ResetTFT();


### PR DESCRIPTION
## Problem

Pumpen zeigen beim ersten Start die Board-Uptime statt 0s. Beispiel FiltPump:
```
ENTERED: UpTime=0ms, millis=38885
OK:      UpTime=40385ms, millis=40387
```
UpTime springt von 0 auf ~40s obwohl nur 1.5s vergangen sind.

## Root Cause

**Dual-Core Race Condition** auf ESP32:

1. `Pump::Start()` prüft `IsRunning()` → `false` ✅
2. `Start()` ruft `Relay::Enable()` auf → I2C-Kommunikation (~1-2ms)
3. **Währenddessen** läuft `Pump::loop()` auf dem anderen Core
4. `loop()` prüft `IsRunning()` → `true` (Relay ist jetzt ON)
5. `loop()` rechnet: `UpTime += millis() - LastLoopMillis`
6. **`LastLoopMillis` ist noch `0`** (wurde erst NACH `Enable()` gesetzt!)
7. Ergebnis: `UpTime += millis() - 0` = ~40000ms auf einmal!

## Fix

`LastLoopMillis = millis()` **VOR** `Relay::Enable()` setzen (statt danach).

## Erwarteter Effekt

| | Vorher | Nachher |
|---|---|---|
| Erster Start UpTime | ~40000ms (Board-Uptime) | 0ms |
| Start nach Stop | Falsch (akkumuliert) | Korrekt |

## Debug-Ausgaben

Nur noch bei **Statusänderung** (kein periodischer Spam):
- `Start()` — OK bei erfolgreichem Start, BLOCKED bei Fehler (UpTimeError, TankLevel, Interlock), FAILED bei Relay-Fehler
- `Stop()` — OK bei erfolgreichem Stop, FAILED bei Relay-Fehler
- ~~`loop()` — periodisch (5s) entfernt~~ (entfernt in 0286f4a)

## Dateien

- `lib/Pump-master/src/Pump.cpp` — Race condition fix + Debug-Ausgaben (nur Statusänderung)